### PR TITLE
SPS-230 Adds Dockerfile for tools image

### DIFF
--- a/images/misc/dsa-re-tools/Dockerfile
+++ b/images/misc/dsa-re-tools/Dockerfile
@@ -1,0 +1,17 @@
+ARG ALPINE_TAG=latest
+FROM alpine:${ALPINE_TAG}
+
+RUN apk -U upgrade \
+    && apk add --no-cache \
+        bash \
+        curl \
+        jq \
+        wget \
+        busybox-extras \
+    && rm -rf /var/cache/apk/*
+
+RUN adduser -D -u 1000 reliabilityenablement
+
+USER 1000
+
+CMD ["/bin/bash", "--login"]


### PR DESCRIPTION
Adds a Dockerfile for a basic tools image, to be used by the team when investigating connectivity issues within a cluster