### PR TITLE
Removes restriction on egress for network policy

### DIFF
--- a/backend/registration-service/registration-service-chart/templates/networkpolicy.yaml
+++ b/backend/registration-service/registration-service-chart/templates/networkpolicy.yaml
@@ -11,16 +11,7 @@ spec:
             matchLabels:
               kubernetes.io/metadata.name: {{ .Release.Namespace }}
   egress:
-    - to:
-      {{- range .Values.namespaceToAllowEgress }}
-      - namespaceSelector:
-          matchLabels:
-            name: {{ . }}
-      {{- end }}
-      {{- range .Values.ipBlockToAllowEgress }}
-      - ipBlock:
-          cidr: {{ . }}
-     {{- end }}
+    - {}
   podSelector:
     matchLabels:
       {{- include "registration-service.selectorLabels" . | nindent 6 }}


### PR DESCRIPTION
Makes the network policy more permissive by allowing egress to all destinations.

The connection to the containerised ActiveGate began to fail at some point, causing the container to not start. I was trying to diagnose what was causing this and by using the 'tools' image I could consistently download the libraries, ruling out a connectivity issue from the namespace.

On closer inspection it seems that the network policy here seems to be the issue. Specifically because the DT URL in use is an ExternalService within the dsa-re-dev namespace rather than going directly to the Service in the Dynatrace namespace.

This change ensures that access is not restricted and therefore both the DT ActiveGate and the RDS instance can be contacted. It is tactical and should be changed down the line to be more permissive. At that point the RDS instance should be hit by IP Range, and either access to the same namspace should be opened for the ExternalService, or the ExternalService should be skipped completely in favour of hitting the svc in the dynatrace namespace for the ActiveGate.