### PR TITLE
Updates namespace ingress policy to use appropriate namespace selector

### DIFF
--- a/backend/registration-service/registration-service-chart/templates/networkpolicy.yaml
+++ b/backend/registration-service/registration-service-chart/templates/networkpolicy.yaml
@@ -7,9 +7,9 @@ metadata:
 spec:
   ingress:
     - from:
-        - namespaceSelector:
-            matchLabels:
-              kubernetes.io/metadata.name: {{ .Release.Namespace }}
+      - namespaceSelector:
+          matchLabels:
+            name: {{ .Release.Namespace }}
   egress:
     - {}
   podSelector:


### PR DESCRIPTION
The previous NetworkPolicy was using the standard k8s label for a namespace, i.e. kubernetes.io/metadata.name. This was cribbed straight from the various Kubernetes guides.

The namespaces on ACP do not use this, they seem to use a label called 'name'. 

The knock on of this is that calls from within the namespace to registration service were being blocked. This now works:

```
$ kubectl run tools -i -t --rm --restart=Never --image=quay.io/ukhomeofficedigital/dsa-re-tools:latest --timeout=15m                                                                       
If you don't see a command prompt, try pressing enter.
$ curl registration-service/actuator                                                                                               
{"_links":{"self":{"href":"http://registration-service/actuator","templated":false},"health-path":{"href":"http://registration-service/actuator/health/{*path}","templated":true},"health":{"href":"http://registration-service/actuator/health","templated":false}}}
```