### PR TITLE
RE-272 Expose Spring Boot metrics via Prometheus

### DIFF
--- a/backend/registration-service/pom.xml
+++ b/backend/registration-service/pom.xml
@@ -43,6 +43,10 @@
 			<artifactId>spring-boot-starter-actuator</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>io.micrometer</groupId>
+			<artifactId>micrometer-registry-prometheus</artifactId>
+		</dependency>
+		<dependency>
 		  <groupId>org.postgresql</groupId>
 			<artifactId>postgresql</artifactId>
 			<scope>runtime</scope>

--- a/backend/registration-service/src/main/resources/application.properties
+++ b/backend/registration-service/src/main/resources/application.properties
@@ -10,5 +10,7 @@ management.endpoint.health.probes.enabled=true
 management.health.livenessState.enabled=true
 management.health.readinessState.enabled=true
 
+management.endpoint.prometheus.enabled=true
+
 # set active profile
 spring.profiles.active=dsa-re-dev


### PR DESCRIPTION
Exposes Spring boot metrics via the Prometheus endpoint.

A second PR will also expose these via Dynatrace, and ideally what this will show is that both can co-exist without the need to write a composite registry.