### PR TITLE
RE-272 Adds Dynatrace custom metric pushing alongside exposed Prometheus metrics

### DIFF
--- a/backend/registration-service/pom.xml
+++ b/backend/registration-service/pom.xml
@@ -47,6 +47,10 @@
 			<artifactId>micrometer-registry-prometheus</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>io.micrometer</groupId>
+			<artifactId>micrometer-registry-dynatrace</artifactId>
+		</dependency>
+		<dependency>
 		  <groupId>org.postgresql</groupId>
 			<artifactId>postgresql</artifactId>
 			<scope>runtime</scope>

--- a/backend/registration-service/registration-service-chart/templates/deployment.yaml
+++ b/backend/registration-service/registration-service-chart/templates/deployment.yaml
@@ -81,6 +81,8 @@ spec:
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           env:
+            - name: GIT_REF
+              value: 
             - name: JAVA_OPTIONS
               value: -Dspring.profiles.active={{ .Release.Namespace }}
             - name: SHOWCASE_SERVICES_DB_ENDPOINT

--- a/backend/registration-service/registration-service-chart/templates/deployment.yaml
+++ b/backend/registration-service/registration-service-chart/templates/deployment.yaml
@@ -81,8 +81,8 @@ spec:
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           env:
-            - name: GIT_REF
-              value: 
+            - name: RANDOM
+              value: {{ randAlphaNum 5 | quote }}
             - name: JAVA_OPTIONS
               value: -Dspring.profiles.active={{ .Release.Namespace }}
             - name: SHOWCASE_SERVICES_DB_ENDPOINT
@@ -110,6 +110,16 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.persistenceCredentialsSecretName }}
                   key: password
+            - name: DYNATRACE_METRICS_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: registration-service-dynatrace-metrics-ingest
+                  key: token
+            - name: DYNATRACE_METRICS_API_URL
+              valueFrom:
+                secretKeyRef:
+                  name: registration-service-dynatrace-metrics-ingest
+                  key: api_url
           {{- if((.Values.dynatrace).podRuntimeInjection).enabled }}
             - name: LD_PRELOAD
               value: /opt/dynatrace/oneagent/agent/lib64/liboneagentproc.so

--- a/backend/registration-service/registration-service-chart/templates/deployment.yaml
+++ b/backend/registration-service/registration-service-chart/templates/deployment.yaml
@@ -88,27 +88,27 @@ spec:
             - name: SHOWCASE_SERVICES_DB_ENDPOINT
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.persistenceCredentialsSecretName }}
+                  name: dsaredevshowcase-rds
                   key: endpoint
             - name: SHOWCASE_SERVICES_DB_PORT
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.persistenceCredentialsSecretName }}
+                  name: dsaredevshowcase-rds
                   key: port
             - name: SHOWCASE_SERVICES_DB_NAME
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.persistenceCredentialsSecretName }}
+                  name: dsaredevshowcase-rds
                   key: default_db
             - name: SHOWCASE_SERVICES_DB_USER
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.persistenceCredentialsSecretName }}
+                  name: dsaredevshowcase-rds
                   key: username
             - name: SHOWCASE_SERVICES_DB_PWD
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.persistenceCredentialsSecretName }}
+                  name: dsaredevshowcase-rds
                   key: password
             - name: DYNATRACE_METRICS_TOKEN
               valueFrom:

--- a/backend/registration-service/registration-service-chart/values-dev.yaml
+++ b/backend/registration-service/registration-service-chart/values-dev.yaml
@@ -18,15 +18,10 @@ imagePullSecrets: []
 dynatrace:
   podRuntimeInjection:
     enabled: true
-  customMetrics:
-    url:
-    tokenSecretName:
 
 image:
   pullPolicy: Always
   # Overrides the image tag whose default is the chart appVersion.
   tag: "latest"
-
-persistenceCredentialsSecretName: dsaredevshowcase-rds
 
 

--- a/backend/registration-service/registration-service-chart/values-dev.yaml
+++ b/backend/registration-service/registration-service-chart/values-dev.yaml
@@ -18,6 +18,9 @@ imagePullSecrets: []
 dynatrace:
   podRuntimeInjection:
     enabled: true
+  customMetrics:
+    url:
+    tokenSecretName:
 
 image:
   pullPolicy: Always
@@ -25,3 +28,5 @@ image:
   tag: "latest"
 
 persistenceCredentialsSecretName: dsaredevshowcase-rds
+
+

--- a/backend/registration-service/src/main/resources/application-dsa-re-dev.properties
+++ b/backend/registration-service/src/main/resources/application-dsa-re-dev.properties
@@ -9,3 +9,8 @@ spring.datasource.url=jdbc:postgresql://${SHOWCASE_SERVICES_DB_ENDPOINT}:${SHOWC
 spring.datasource.username=${SHOWCASE_SERVICES_DB_USER}
 spring.datasource.password=${SHOWCASE_SERVICES_DB_PWD}
 
+# dynatrace custom metrics
+management.dynatrace.metrics.export.uri=${DYNATRACE_METRICS_API_URL}
+management.dynatrace.metrics.export.api-token=${DYNATRACE_METRICS_TOKEN}
+management.dynatrace.metrics.export.v2.metric-key-prefix=dsa.re.registration-service
+

--- a/backend/registration-service/src/main/resources/application.properties
+++ b/backend/registration-service/src/main/resources/application.properties
@@ -18,7 +18,7 @@ management.health.readinessState.enabled=true
 management.health.diskSpace.enabled=true
 
 management.endpoints.enabled-by-default: false
-management.endpoints.web.exposure.include="*"
+management.endpoints.web.exposure.include=*
 
 # set active profile
 spring.profiles.active=dsa-re-dev

--- a/backend/registration-service/src/main/resources/application.properties
+++ b/backend/registration-service/src/main/resources/application.properties
@@ -11,7 +11,7 @@ management.endpoint.prometheus.enabled=true
 management.health.livenessState.enabled=true
 management.health.readinessState.enabled=true
 
-management.endpoints.web.exposure.include=health.metrics
+management.endpoints.web.exposure.include=health,metrics
 
 # set active profile
 spring.profiles.active=dsa-re-dev

--- a/backend/registration-service/src/main/resources/application.properties
+++ b/backend/registration-service/src/main/resources/application.properties
@@ -6,12 +6,19 @@ spring.jpa.properties.hibernate.format_sql=true
 
 server.error.include-message=always
 
+
+management.endpoint.health.enabled=true
 management.endpoint.health.probes.enabled=true
+management.endpoint.health.show-details=always
+
 management.endpoint.prometheus.enabled=true
+
 management.health.livenessState.enabled=true
 management.health.readinessState.enabled=true
+management.health.diskSpace.enabled=true
 
-management.endpoints.web.exposure.include=health,metrics
+management.endpoints.enabled-by-default: false
+management.endpoints.web.exposure.include="*"
 
 # set active profile
 spring.profiles.active=dsa-re-dev

--- a/backend/registration-service/src/main/resources/application.properties
+++ b/backend/registration-service/src/main/resources/application.properties
@@ -7,10 +7,11 @@ spring.jpa.properties.hibernate.format_sql=true
 server.error.include-message=always
 
 management.endpoint.health.probes.enabled=true
+management.endpoint.prometheus.enabled=true
 management.health.livenessState.enabled=true
 management.health.readinessState.enabled=true
 
-management.endpoint.prometheus.enabled=true
+management.endpoints.web.exposure.include=health.metrics
 
 # set active profile
 spring.profiles.active=dsa-re-dev


### PR DESCRIPTION
Exposes metrics to both Prometheus and Dynatrace concurrently

### Background
Several teams have asked whether it is possible to expose the Spring Boot metrics (and other custom metrics) to Prometheus and Dynatrace concurrently. 

The Spring Boot Actuator project has support for making available a Prometheus endpoint which exposes Spring Boot's metrics. These can then be scraped by Prometheus exporters and graphed from there. Under the hood of exposing these metrics is the micrometer library.

We were initially unsure whether the micrometer Dynatrace libraries could co-exist, and the micrometer website suggested the use of a [CompositeRegistry](https://docs.micrometer.io/micrometer/reference/concepts/registry.html#_composite_registries) which would include both the dynatrace and prometheus libraries.

Looking at [the Spring Boot docs](https://docs.spring.io/spring-boot/reference/actuator/metrics.html#actuator.metrics.getting-started), it appeared that Spring was doing the heavy lifting to achieve this:

> Spring Boot auto-configures a composite [MeterRegistry](https://javadoc.io/doc/io.micrometer/micrometer-core/1.14.2/io/micrometer/core/instrument/MeterRegistry.html) and adds a registry to the composite for each of the supported implementations that it finds on the classpath. Having a dependency on micrometer-registry-{system} in your runtime classpath is enough for Spring Boot to configure the registry.

This PR has been tested and confirms this is indeed the case - Prometheus metrics can be made available to pull alongside a Dynatrace push with zero code changes, simply the addition of the library on the classpath and some YAML/properties update with the relevant URLs and tokens.