### PR TITLE
Updates invalid property file around endpoint exposure

### DIFF
--- a/backend/registration-service/src/main/resources/application.properties
+++ b/backend/registration-service/src/main/resources/application.properties
@@ -17,13 +17,11 @@ management.health.livenessState.enabled=true
 management.health.readinessState.enabled=true
 management.health.diskSpace.enabled=true
 
-management.endpoints.enabled-by-default: false
-management.endpoints.web.exposure.include=*
+management.endpoints.enabled-by-default=false
+management.endpoints.web.exposure.include=health,metrics,info,prometheus
 
 # set active profile
 spring.profiles.active=dsa-re-dev
 
 # Drop DB schema before running migrations
 spring.liquibase.drop-first=true
-
-


### PR DESCRIPTION
I believe the issues around the pod restarting are my fault and come from when I was tweaking the service to push metrics to Dynatrace. Kubernetes is clearly showing that the probes are failing, and looking at the .properties file I have invalid properties in there.