### PR TITLE
Setup persistent storage

### DIFF
--- a/backend/registration-service/pom.xml
+++ b/backend/registration-service/pom.xml
@@ -67,7 +67,6 @@
 		<dependency>
 			<groupId>org.springframework.kafka</groupId>
 			<artifactId>spring-kafka</artifactId>
-			<version>3.0.10</version>
 		</dependency>
 	</dependencies>
 

--- a/backend/registration-service/pom.xml
+++ b/backend/registration-service/pom.xml
@@ -27,7 +27,7 @@
 		<url/>
 	</scm>
 	<properties>
-		<java.version>21</java.version>
+		<java.version>19</java.version>
 	</properties>
 	<dependencies>
 		<dependency>
@@ -63,6 +63,11 @@
 		<dependency>
 			<groupId>org.liquibase</groupId>
 			<artifactId>liquibase-core</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.kafka</groupId>
+			<artifactId>spring-kafka</artifactId>
+			<version>2.9.9</version>
 		</dependency>
 	</dependencies>
 

--- a/backend/registration-service/pom.xml
+++ b/backend/registration-service/pom.xml
@@ -27,7 +27,7 @@
 		<url/>
 	</scm>
 	<properties>
-		<java.version>19</java.version>
+		<java.version>21</java.version>
 	</properties>
 	<dependencies>
 		<dependency>
@@ -67,7 +67,7 @@
 		<dependency>
 			<groupId>org.springframework.kafka</groupId>
 			<artifactId>spring-kafka</artifactId>
-			<version>2.9.11</version>
+			<version>3.0.10</version>
 		</dependency>
 	</dependencies>
 

--- a/backend/registration-service/pom.xml
+++ b/backend/registration-service/pom.xml
@@ -67,7 +67,7 @@
 		<dependency>
 			<groupId>org.springframework.kafka</groupId>
 			<artifactId>spring-kafka</artifactId>
-			<version>2.9.9</version>
+			<version>2.9.11</version>
 		</dependency>
 	</dependencies>
 

--- a/backend/registration-service/registration-service-chart/templates/deployment.yaml
+++ b/backend/registration-service/registration-service-chart/templates/deployment.yaml
@@ -118,7 +118,7 @@ spec:
           {{- if((.Values.dynatrace).podRuntimeInjection).enabled }}
             - name: LD_PRELOAD
               value: /opt/dynatrace/oneagent/agent/lib64/liboneagentproc.so
-          {{- end -}}
+          {{- end }}
           volumeMounts:
           {{- if((.Values.dynatrace).podRuntimeInjection).enabled }}
             - name: {{ (((.Values).dynatrace).podRuntimeInjection).volumeName | default "oneagent" }}

--- a/backend/registration-service/registration-service-chart/templates/deployment.yaml
+++ b/backend/registration-service/registration-service-chart/templates/deployment.yaml
@@ -119,16 +119,21 @@ spec:
             - name: LD_PRELOAD
               value: /opt/dynatrace/oneagent/agent/lib64/liboneagentproc.so
           {{- end -}}
-          {{- if((.Values.dynatrace).podRuntimeInjection).enabled }}
           volumeMounts:
+          {{- if((.Values.dynatrace).podRuntimeInjection).enabled }}
             - name: {{ (((.Values).dynatrace).podRuntimeInjection).volumeName | default "oneagent" }}
               mountPath: /opt/dynatrace/oneagent
-          {{- end -}}
-      {{- if((.Values.dynatrace).podRuntimeInjection).enabled }}
+          {{- end }}
+            - name: kafka-tls-storage
+              mountPath: /etc/kafka-tls
       volumes:
+      {{- if ((.Values.dynatrace).podRuntimeInjection).enabled }}
         - name: {{ (((.Values).dynatrace).podRuntimeInjection).volumeName | default "oneagent" }}
           emptyDir: {}
-      {{- end -}}
+      {{- end }}
+        - name: kafka-tls-storage
+          persistentVolumeClaim:
+            claimName: showcase-storage-pvc
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/backend/registration-service/registration-service-chart/values.yaml
+++ b/backend/registration-service/registration-service-chart/values.yaml
@@ -59,6 +59,10 @@ autoscaling:
   targetCPUUtilizationPercentage: 80
   # targetMemoryUtilizationPercentage: 80
 
+image:
+  pullPolicy: IfNotPresent
+  tag: "latest"
+
 
 nodeSelector: {}
 

--- a/backend/registration-service/src/main/java/com_example_registration_service/RegistrationProducer.java
+++ b/backend/registration-service/src/main/java/com_example_registration_service/RegistrationProducer.java
@@ -1,0 +1,23 @@
+package com_example_registration_service;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+public class RegistrationProducer {
+
+    private final KafkaTemplate<String, String> kafkaTemplate;
+
+    @Value("${kafka.topic.user-login}")
+    private String topic;
+
+    public RegistrationProducer(KafkaTemplate<String, String> kafkaTemplate) {
+        this.kafkaTemplate = kafkaTemplate;
+    }
+
+    public void sendMessage(String message) {
+        kafkaTemplate.send(topic, message);
+        System.out.println("Message sent to Kafka: " + message);
+    }
+}

--- a/backend/registration-service/src/main/java/com_example_registration_service/RegistrationProducer.java
+++ b/backend/registration-service/src/main/java/com_example_registration_service/RegistrationProducer.java
@@ -9,7 +9,7 @@ public class RegistrationProducer {
 
     private final KafkaTemplate<String, String> kafkaTemplate;
 
-    @Value("${kafka.topic.user-login}")
+    @Value("${spring.kafka.topic.user-login}")
     private String topic;
 
     public RegistrationProducer(KafkaTemplate<String, String> kafkaTemplate) {

--- a/backend/registration-service/src/main/java/com_example_registration_service/user/UserService.java
+++ b/backend/registration-service/src/main/java/com_example_registration_service/user/UserService.java
@@ -1,5 +1,7 @@
 package com_example_registration_service.user;
 
+import com_example_registration_service.*;
+
 import java.util.List;
 import java.util.Optional;
 
@@ -22,6 +24,10 @@ public class UserService {
   public UserService(UserRepository userRepository) {
         this.userRepository = userRepository;
     }
+  
+  // Inject the Kafka producer
+  @Autowired // ADDED
+  private RegistrationProducer registrationProducer; // ADDED
   
   public List<User> getUsers() {
       return userRepository.findAll();
@@ -73,6 +79,12 @@ public User updateUser(Long userId, User updatedUser) {
 
       if (userOptional.get().getPassword().equals(password)) {
         logger.debug("Passwords match!");
+
+        // Send Kafka message on successful login
+        String message = "User logged in: " + email; // ADDED
+        registrationProducer.sendMessage(message); // ADDED
+        logger.info("Kafka message sent: {}", message); // ADDED
+
         return userOptional;
       } else {
         logger.debug("Password mismatch!");

--- a/backend/registration-service/src/main/resources/application-dsa-re-dev.properties
+++ b/backend/registration-service/src/main/resources/application-dsa-re-dev.properties
@@ -15,10 +15,10 @@ management.dynatrace.metrics.export.api-token=${DYNATRACE_METRICS_TOKEN}
 management.dynatrace.metrics.export.v2.metric-key-prefix=dsa.re.registration-service
 
 # kafka config
-kafka.bootstrap-servers=b-1.dsaredevshowcase.rfkas2.c2.kafka.eu-west-2.amazonaws.com:9094,b-2.dsaredevshowcase.rfkas2.c2.kafka.eu-west-2.amazonaws.com:9094
-kafka.topic.user-login=user-login
-kafka.properties.security.protocol=SSL
-kafka.properties.ssl.truststore.location=/etc/kafka-tls/cacerts
-kafka.properties.ssl.truststore.password=changeit
-kafka.properties.ssl.keystore.location=/etc/kafka-tls/kafka-client.2025-01-22.103508/app-msk-kafka-client.jks
-kafka.properties.ssl.keystore.password=changeit321
+spring.kafka.bootstrap-servers=b-1.dsaredevshowcase.rfkas2.c2.kafka.eu-west-2.amazonaws.com:9094,b-2.dsaredevshowcase.rfkas2.c2.kafka.eu-west-2.amazonaws.com:9094
+spring.kafka.topic.user-login=user-login
+spring.kafka.properties.security.protocol=SSL
+spring.kafka.properties.ssl.truststore.location=/etc/kafka-tls/cacerts
+spring.kafka.properties.ssl.truststore.password=changeit
+spring.kafka.properties.ssl.keystore.location=/etc/kafka-tls/kafka-client.2025-01-22.103508/app-msk-kafka-client.jks
+spring.kafka.properties.ssl.keystore.password=changeit321

--- a/backend/registration-service/src/main/resources/application-dsa-re-dev.properties
+++ b/backend/registration-service/src/main/resources/application-dsa-re-dev.properties
@@ -14,3 +14,11 @@ management.dynatrace.metrics.export.uri=${DYNATRACE_METRICS_API_URL}
 management.dynatrace.metrics.export.api-token=${DYNATRACE_METRICS_TOKEN}
 management.dynatrace.metrics.export.v2.metric-key-prefix=dsa.re.registration-service
 
+# kafka config
+kafka.bootstrap-servers=b-1.dsaredevshowcase.rfkas2.c2.kafka.eu-west-2.amazonaws.com:9094,b-2.dsaredevshowcase.rfkas2.c2.kafka.eu-west-2.amazonaws.com:9094
+kafka.topic.user-login=user-login
+kafka.properties.security.protocol=SSL
+kafka.properties.ssl.truststore.location=/etc/kafka-tls/cacerts
+kafka.properties.ssl.truststore.password=changeit
+kafka.properties.ssl.keystore.location=/etc/kafka-tls/kafka-client.2025-01-22.103508/app-msk-kafka-client.jks
+kafka.properties.ssl.keystore.password=changeit321

--- a/images/misc/dsa-re-tools/Dockerfile
+++ b/images/misc/dsa-re-tools/Dockerfile
@@ -11,6 +11,7 @@ RUN apk -U upgrade \
         openjdk11 \
         openssl \
         aws-cli \
+        postgresql-client \
     && rm -rf /var/cache/apk/*
 
 # Download and install kafka

--- a/k8s/showcase-storage-pvc.yaml
+++ b/k8s/showcase-storage-pvc.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: showcase-storage-pvc
+  namespace: dsa-re-dev
+spec:
+  accessModes:
+    - ReadWriteOnce
+  volumeMode: Filesystem
+  resources:
+    requests:
+      storage: 1Gi
+  storageClassName: gp2-encrypted


### PR DESCRIPTION
This branch was created for creation of persistent volume claim and apache kafka integration. Includes the following changes:
- PVC yaml file for PVC creation - PVC will be used for storage of mTLS docs and kafka client binaries
- Kafka properties added to registration service
- Logic for kafka producer added to UserService and RegistrationProducer files
- RegistrationService deployment.yaml updated to include volume and volume mount
- Spring-kafka dependency added to pom 