### PR TITLE
Set java resource allocation and probe limits

### DIFF
--- a/backend/registration-service/registration-service-chart/templates/deployment.yaml
+++ b/backend/registration-service/registration-service-chart/templates/deployment.yaml
@@ -65,14 +65,18 @@ spec:
             httpGet:
               path: /actuator/health/liveness
               port: http
-            initialDelaySeconds: 30
+            initialDelaySeconds: 120
             periodSeconds: 30
+            timeoutSeconds: 10
+            failureThreshold: 3
           readinessProbe:
             httpGet:
               path: /actuator/health/readiness
               port: http
-            initialDelaySeconds: 60
+            initialDelaySeconds: 120
             periodSeconds: 30
+            timeoutSeconds: 10
+            failureThreshold: 3
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           env:
@@ -115,6 +119,10 @@ spec:
                 secretKeyRef:
                   name: registration-service-dynatrace-metrics-ingest
                   key: api_url
+            - name: JAVA_OPTS
+              value: "-Xms256m -Xmx400m"
+            - name: KAFKA_CONFIG
+              value: "/etc/kafka-tls/client.properties"
           {{- if((.Values.dynatrace).podRuntimeInjection).enabled }}
             - name: LD_PRELOAD
               value: /opt/dynatrace/oneagent/agent/lib64/liboneagentproc.so

--- a/backend/registration-service/registration-service-chart/values.yaml
+++ b/backend/registration-service/registration-service-chart/values.yaml
@@ -40,17 +40,13 @@ ingress:
   #    hosts:
   #      - chart-example.local
 
-resources: {}
-  # We usually recommend not to specify default resources and to leave this as a conscious
-  # choice for the user. This also increases chances charts run on environments with little
-  # resources, such as Minikube. If you do want to specify resources, uncomment the following
-  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-  # limits:
-  #   cpu: 100m
-  #   memory: 128Mi
-  # requests:
-  #   cpu: 100m
-  #   memory: 128Mi
+resources:
+  limits:
+    cpu: 500m
+    memory: 512Mi
+  requests:
+    cpu: 250m
+    memory: 256Mi
 
 autoscaling:
   enabled: false

--- a/backend/registration-service/src/main/resources/application-dsa-re-dev.properties
+++ b/backend/registration-service/src/main/resources/application-dsa-re-dev.properties
@@ -22,3 +22,9 @@ spring.kafka.properties.ssl.truststore.location=/etc/kafka-tls/cacerts
 spring.kafka.properties.ssl.truststore.password=changeit
 spring.kafka.properties.ssl.keystore.location=/etc/kafka-tls/kafka-client.2025-01-22.103508/app-msk-kafka-client.jks
 spring.kafka.properties.ssl.keystore.password=changeit321
+
+# Kafka Producer settings (memory management)
+spring.kafka.producer.batch-size=8192  
+spring.kafka.producer.acks=1  
+spring.kafka.producer.retries=3  
+spring.kafka.producer.max-in-flight-requests-per-connection=1  


### PR DESCRIPTION
Due to registration service crashing due to OOMKilled errors, and also failure on health and readiness probes, the following changes were made:
- delayseconds, timeouts and failure thresholds set for registration-service
- pod resources for limits and requests set in values.yaml
- kafka producer limits set in  registration-service application-dsa-re-dev.properties