### PR TITLE
Setup kafka chron job

### DIFF
--- a/backend/registration-service/Dockerfile
+++ b/backend/registration-service/Dockerfile
@@ -30,6 +30,12 @@ FROM quay.io/ukhomeofficedigital/dsa-re-amazoncorretto:21.0.5-alpine3.20
 #Set working directory
 WORKDIR /app
 
+# Install Kafka client dependencies (Kafka tools)
+RUN apk add --no-cache bash wget && \
+    wget https://archive.apache.org/dist/kafka/3.0.0/kafka_2.13-3.0.0.tgz && \
+    tar -xzvf kafka_2.13-3.0.0.tgz && \
+    rm kafka_2.13-3.0.0.tgz
+
 # Copy over jar from stage 1
 COPY --from=builder app/target/registration-service-0.0.1-SNAPSHOT.jar app.jar
 

--- a/backend/registration-service/src/main/java/com_example_registration_service/RegistrationProducer.java
+++ b/backend/registration-service/src/main/java/com_example_registration_service/RegistrationProducer.java
@@ -9,15 +9,24 @@ public class RegistrationProducer {
 
     private final KafkaTemplate<String, String> kafkaTemplate;
 
+    // Inject kafka-topics
     @Value("${spring.kafka.topic.user-login}")
-    private String topic;
+    private String loginTopic;
+
+    @Value("${spring.kafka.topic.user-registration}")
+    private String registrationTopic;
 
     public RegistrationProducer(KafkaTemplate<String, String> kafkaTemplate) {
         this.kafkaTemplate = kafkaTemplate;
     }
 
-    public void sendMessage(String message) {
-        kafkaTemplate.send(topic, message);
-        System.out.println("Message sent to Kafka: " + message);
+    public void sendLoginMessage(String message) {
+        kafkaTemplate.send(loginTopic, message);
+        System.out.println("Login message sent to Kafka: " + message);
+    }
+
+    public void sendRegistrationMessage(String message) {
+        kafkaTemplate.send(registrationTopic, message);
+        System.out.println("Registration message sent to Kafka: " + message);
     }
 }

--- a/backend/registration-service/src/main/resources/application-dsa-re-dev.properties
+++ b/backend/registration-service/src/main/resources/application-dsa-re-dev.properties
@@ -17,6 +17,7 @@ management.dynatrace.metrics.export.v2.metric-key-prefix=dsa.re.registration-ser
 # kafka config
 spring.kafka.bootstrap-servers=b-1.dsaredevshowcase.rfkas2.c2.kafka.eu-west-2.amazonaws.com:9094,b-2.dsaredevshowcase.rfkas2.c2.kafka.eu-west-2.amazonaws.com:9094
 spring.kafka.topic.user-login=user-login
+spring.kafka.topic.user-login=user-registration
 spring.kafka.properties.security.protocol=SSL
 spring.kafka.properties.ssl.truststore.location=/etc/kafka-tls/cacerts
 spring.kafka.properties.ssl.truststore.password=changeit

--- a/backend/registration-service/src/main/resources/application-dsa-re-dev.properties
+++ b/backend/registration-service/src/main/resources/application-dsa-re-dev.properties
@@ -17,7 +17,7 @@ management.dynatrace.metrics.export.v2.metric-key-prefix=dsa.re.registration-ser
 # kafka config
 spring.kafka.bootstrap-servers=b-1.dsaredevshowcase.rfkas2.c2.kafka.eu-west-2.amazonaws.com:9094,b-2.dsaredevshowcase.rfkas2.c2.kafka.eu-west-2.amazonaws.com:9094
 spring.kafka.topic.user-login=user-login
-spring.kafka.topic.user-login=user-registration
+spring.kafka.topic.user-registration=user-registration
 spring.kafka.properties.security.protocol=SSL
 spring.kafka.properties.ssl.truststore.location=/etc/kafka-tls/cacerts
 spring.kafka.properties.ssl.truststore.password=changeit

--- a/frontend/frontend-service/src/pages/registration/Registration.js
+++ b/frontend/frontend-service/src/pages/registration/Registration.js
@@ -32,16 +32,21 @@ const Registration = () => {
         body: JSON.stringify(formData),
       });
 
-      if (!response.ok) {
-        const errorData = await response.json();
-        throw new Error(errorData.message || "Something went wrong!");
+      if (response.ok) {
+        console.log("Registration successful");
+        const user = await response.json();
+        if (user.role === "customer") {
+          navigate("/catalogue");
+        } else {
+          navigate("/admin");
+        }
+      } else {
+        const message = await response.text();
+        setError(message);
       }
-
-      const data = await response.json();
-      console.log("User registered successfully:", data);
-      navigate("/catalogue");
     } catch (error) {
-      console.error("Error:", error);
+      console.error("Error during registration:", error);
+      setError("An error occurred. Please try again.");
     }
   };
 

--- a/frontend/frontend-service/src/pages/registration/Registration.js
+++ b/frontend/frontend-service/src/pages/registration/Registration.js
@@ -13,6 +13,8 @@ const Registration = () => {
     role: "",
   });
 
+  const [error, setError] = useState(null);
+
   const navigate = useNavigate();
 
   const handleChange = (e) => {

--- a/images/misc/msk-cron-job/Dockerfile
+++ b/images/misc/msk-cron-job/Dockerfile
@@ -2,7 +2,7 @@
 FROM alpine:latest
 
 # Install curl
-RUN apk add --no-cache curl
+RUN apk add --no-cache curl bash
 
 # Set the working directory to /app
 WORKDIR /app
@@ -16,4 +16,4 @@ RUN adduser -D -u 1000 reliabilityenablement
 USER 1000
 
 # Set entrypoint
-ENTRYPOINT [ "/app/trigger_login.sh" ]
+ENTRYPOINT [ "/bin/bash", "/app/trigger_login.sh" ]

--- a/images/misc/msk-cron-job/Dockerfile
+++ b/images/misc/msk-cron-job/Dockerfile
@@ -1,0 +1,19 @@
+# Using base alpine image
+FROM alpine:latest
+
+# Install curl
+RUN apk add --no-cache curl
+
+# Set the working directory to /app
+WORKDIR /app
+
+# Copy script into container
+COPY trigger_login.sh /app/trigger_login.sh
+RUN chmod +x /app/trigger_login.sh
+
+RUN adduser -D -u 1000 reliabilityenablement
+
+USER 1000
+
+# Set entrypoint
+ENTRYPOINT [ "/app/trigger_login.sh" ]

--- a/images/misc/msk-cron-job/trigger_login.sh
+++ b/images/misc/msk-cron-job/trigger_login.sh
@@ -1,9 +1,23 @@
 #!/bin/bash
+set -e
 
-# Configuration
 REGISTRATION_SERVICE_URL="http://frontend-service.dev.dsa-re-notprod.homeoffice.gov.uk/api/v1/user"
-EMAIL="Chris.Hunter@gmail.com"
-PASSWORD="chrispassword"
+
+# Existing users
+USER1_EMAIL="Chris.Hunter@gmail.com"
+USER1_PASSWORD="chrispassword"
+
+USER2_EMAIL="Michael.McCarthy@gmail.com"
+USER2_PASSWORD="michaelpassword"
+
+# Select user
+if [ $(($RANDOM % 2)) -eq 0 ]; then
+	EMAIL=$USER1_EMAIL
+	PASSWORD=$USER1_PASSWORD
+else
+	EMAIL=$USER2_EMAIL
+	PASSWORD=$USER2_PASSWORD
+fi
 
 # Simulate login
 echo "Simulating login for user: $EMAIL"

--- a/images/misc/msk-cron-job/trigger_login.sh
+++ b/images/misc/msk-cron-job/trigger_login.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# Configuration
+REGISTRATION_SERVICE_URL="http://frontend-service.dev.dsa-re-notprod.homeoffice.gov.uk/api/v1/user"
+EMAIL="Chris.Hunter@gmail.com"
+PASSWORD="chrispassword"
+
+# Simulate login
+echo "Simulating login for user: $EMAIL"
+response=$(curl -v -s -o /dev/null -w "%{http_code}" \
+	-X POST "$REGISTRATION_SERVICE_URL/login" \
+	-H "Content-Type: application/json" \
+	-d "{\"email\": \"$EMAIL\", \"password\": \"$PASSWORD\"}")
+
+# Check response
+if [ "$response" -eq 200 ]; then
+	echo "Simulated login successfully"
+else 
+	echo "Sumilated login failed with HTTP status: $response"
+fi

--- a/k8s/msk-cronjob.yaml
+++ b/k8s/msk-cronjob.yaml
@@ -4,9 +4,13 @@ metadata:
   name: trigger-login
   namespace: dsa-re-dev
 spec:
-  schedule: "*/3 * * * *"
+  schedule: "*/10 * * * *"
+  startingDeadlineSeconds: 300
+  successfulJobsHistoryLimit: 0
+  failedJobsHistoryLimit: 1
   jobTemplate:
     spec:
+      ttlSecondsAfterFinished: 30
       template:
         spec:
           containers:

--- a/k8s/msk-cronjob.yaml
+++ b/k8s/msk-cronjob.yaml
@@ -1,0 +1,16 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: trigger-login
+  namespace: dsa-re-dev
+spec:
+  schedule: "*/3 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: trigger-login
+            image: "quay.io/ukhomeofficedigital/dsa-re-msk-cron:latest"
+            imagePullPolicy: Always
+          restartPolicy: OnFailure


### PR DESCRIPTION
This feature branch was for the creation of a script to be executed at regular intervals by a k8s cron job to simulate user traffic on our msk **user-login** topic, so that we can see consistent traffic to msk on Dynatrace SAAS and consisted of the following changes:

- Added kafka client to registration-service image (for ease of use in future)
- Addition of methods in RegistrationProducer.java to create login and new-user registration messages
- Added message creation to UserService.java
- new script trigger-login.sh created which randomly selects one of the 2 pre-populated users and logs them into registration service via curl POST request to the _/login_ endpoint
- msk-cronjob Dockerfile created to run the trigger-login.sh script
- msk-cronjob.yaml for cronjob creation and configuration, which will run the newly created container