### PR TITLE
RE-361 Ensures JAVA_OPTS are passed through to the registration service app

### DIFF
--- a/backend/registration-service/Dockerfile
+++ b/backend/registration-service/Dockerfile
@@ -43,4 +43,4 @@ COPY --from=builder app/target/registration-service-0.0.1-SNAPSHOT.jar app.jar
 EXPOSE 8080
 
 # Run Springboot app
-ENTRYPOINT [ "java", "-jar", "app.jar" ]
+ENTRYPOINT [ "java", "$JAVA_OPTS", "-jar", "app.jar" ]

--- a/backend/registration-service/registration-service-chart/templates/deployment.yaml
+++ b/backend/registration-service/registration-service-chart/templates/deployment.yaml
@@ -69,7 +69,7 @@ spec:
               cpu: 100m
               memory: 512Mi
           command: ["/bin/sh"]
-          args: ["-c", "keytool -importkeystore -srckeystore $JAVA_HOME/lib/security/cacerts -destkeystore /certs/custom_truststore.jks -srcstoretype JKS -deststoretype JKS -storepass changeit"]
+          args: ["-c", "keytool -importkeystore -srckeystore $JAVA_HOME/lib/security/cacerts -destkeystore /certs/custom_truststore.jks -srcstoretype JKS -deststoretype JKS -storepass changeit -noprompt && keytool -import -alias ACPRootCA -keystore /certs/custom_truststore.jks -file /etc/ssl/certs/acp-root.crt -storepass changeit -noprompt"]
           volumeMounts:
             - name: bundle
               mountPath: /etc/ssl/certs
@@ -144,6 +144,8 @@ spec:
             - name: JAVA_OPTS
               value: >
                 -Xms256m -Xmx400m
+                -Djavax.net.ssl.trustStore=/certs/custom_truststore.jks
+                -Djavax.net.ssl.trustStorePassword=changeit
             - name: KAFKA_CONFIG
               value: "/etc/kafka-tls/client.properties"
           {{- if((.Values.dynatrace).podRuntimeInjection).enabled }}

--- a/backend/registration-service/registration-service-chart/templates/deployment.yaml
+++ b/backend/registration-service/registration-service-chart/templates/deployment.yaml
@@ -31,8 +31,8 @@ spec:
         fsGroup: 1000
         runAsNonRoot: true
         runAsUser: 1000
-      {{- if((.Values.dynatrace).podRuntimeInjection).enabled }}
       initContainers:
+      {{- if((.Values.dynatrace).podRuntimeInjection).enabled }}
         - name: install-oneagent
           image: quay.io/ukhomeofficedigital/dsa-re-dynatrace-oneagent-pod-runtime-injection:1.0.0
           env:
@@ -53,7 +53,29 @@ spec:
           volumeMounts:
             - mountPath: /opt/dynatrace/oneagent
               name: {{ (((.Values).dynatrace).podRuntimeInjection).volumeName | default "oneagent" }}
-      {{- end }}
+        {{- end }}
+        - name: configure-truststore
+          image: "quay.io/ukhomeofficedigital/dsa-re-registration-service:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          env:
+            - name: TRUSTSTORE_RUNTIME
+              value: /certs
+            - name: TRUSTSTORE_PASSWORD
+              value: changeit    
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+          resources:
+            limits:
+              cpu: 100m
+              memory: 512Mi
+          command: ["/bin/sh"]
+          args: ["-c", "keytool -importkeystore -srckeystore $JAVA_HOME/lib/security/cacerts -destkeystore /certs/custom_truststore.jks -srcstoretype JKS -deststoretype JKS -storepass changeit"]
+          volumeMounts:
+            - name: bundle
+              mountPath: /etc/ssl/certs
+              readOnly: true
+            - name: certs
+              mountPath: /certs
       containers:
         - name: {{ .Chart.Name }}
           image: "quay.io/ukhomeofficedigital/dsa-re-registration-service:{{ .Values.image.tag | default .Chart.AppVersion }}"
@@ -120,7 +142,8 @@ spec:
                   name: registration-service-dynatrace-metrics-ingest
                   key: api_url
             - name: JAVA_OPTS
-              value: "-Xms256m -Xmx400m"
+              value: >
+                -Xms256m -Xmx400m
             - name: KAFKA_CONFIG
               value: "/etc/kafka-tls/client.properties"
           {{- if((.Values.dynatrace).podRuntimeInjection).enabled }}
@@ -134,6 +157,9 @@ spec:
           {{- end }}
             - name: kafka-tls-storage
               mountPath: /etc/kafka-tls
+            - name: certs
+              mountPath: /certs
+              readOnly: true
       volumes:
       {{- if ((.Values.dynatrace).podRuntimeInjection).enabled }}
         - name: {{ (((.Values).dynatrace).podRuntimeInjection).volumeName | default "oneagent" }}
@@ -142,6 +168,13 @@ spec:
         - name: kafka-tls-storage
           persistentVolumeClaim:
             claimName: showcase-storage-pvc
+        - name: certs
+          emptyDir: {}
+        - name: secrets
+          emptyDir: {}
+        - name: bundle
+          configMap:
+            name: bundle
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
The work on passing custom truststores has revealed that custom java options are not respected within the actual running container. This is because JAVA_OPTS was not passed through.