### PR TITLE
RE-361 Switches Java invocation to use variable expansion

### DIFF
--- a/backend/registration-service/Dockerfile
+++ b/backend/registration-service/Dockerfile
@@ -43,4 +43,4 @@ COPY --from=builder app/target/registration-service-0.0.1-SNAPSHOT.jar app.jar
 EXPOSE 8080
 
 # Run Springboot app
-ENTRYPOINT [ "java", "$JAVA_OPTS", "-jar", "app.jar" ]
+ENTRYPOINT [ "sh", "-c", "exec java $JAVA_OPTS -jar app.jar" ]


### PR DESCRIPTION
When JAVA_OPTS or other variables need to be passed, any dynamic arguments are not expanded.

This means you get something like this:

```
Defaulted container "registration-service" out of: registration-service, install-oneagent (init), configure-truststore (init)
Error: Could not find or load main class $JAVA_OPTS
Caused by: java.lang.ClassNotFoundException: $JAVA_OPTS
```
which is obviously not ideal.

Instead we need the shell form for variable expansion.