### PR TITLE
RE-361 Ensures Spring Profile is passed via Java options

### DIFF
--- a/backend/registration-service/registration-service-chart/templates/deployment.yaml
+++ b/backend/registration-service/registration-service-chart/templates/deployment.yaml
@@ -104,8 +104,6 @@ spec:
           env:
             - name: RANDOM
               value: {{ randAlphaNum 5 | quote }}
-            - name: JAVA_OPTIONS
-              value: -Dspring.profiles.active={{ .Release.Namespace }}
             - name: SHOWCASE_SERVICES_DB_ENDPOINT
               valueFrom:
                 secretKeyRef:
@@ -144,6 +142,7 @@ spec:
             - name: JAVA_OPTS
               value: >
                 -Xms256m -Xmx400m
+                -Dspring.profiles.active={{ .Release.Namespace }}
                 -Djavax.net.ssl.trustStore=/certs/custom_truststore.jks
                 -Djavax.net.ssl.trustStorePassword=changeit
             - name: KAFKA_CONFIG


### PR DESCRIPTION
The Spring Profile until now has been set by a Java option that has not actually been used within the container. This explains why the profile is hardcoded within application.properties.

@chriswhunter89 This should be one step towards making it easier to spin this service up locally - the dsa-re-dev profile should be very specific to only running on an environment with Dynatrace.