### PR TITLE
RE-30: postgres container metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ The system is designed around a fictional scenario, "**Rent a Unicorn**," where 
   - [Kafka Topics and Messaging](#kafka-topics-and-messaging)
   - [CronJob - Simulated User Login](#cronjob---simulated-user-login)
   - [Custom Metric - Counter](#custom-metric---counter)
+  - [Custom Metric - Counter Container DB](#custom-metric---counter-container-db)
   - [Setup](#setup)
     - [Clone the Monorepo](#clone-the-monorepo)
   - [Deploying to Kubernetes](#deploying-to-kubernetes)
@@ -110,6 +111,11 @@ Each microservice resides in its own subdirectory within the monorepo.
 
 - A **Counter** for the number of logins show how to publish custom metrics from the python code to any backend by OpenTelemetry (OTLP).
 - The notification-service custom_metric.py provide the set up module and the kafka_consumer.py include an increment counter trigger which data you can fetch in your backend monitoring tool.
+  
+## Custom Metric - Counter Container DB
+
+- A logins **Counter** have been created that save the count in a container db deployed in kubernetes. There are two counters, one that increase the count in the database and another counter that provides the total of logins from the db.
+- The notification-service otel_config.py provide the set up module for OTLP and the db.py that include the database connection, counters and logic.
 ---
 
 ## Setup

--- a/backend/notification-service/custom_metric.py
+++ b/backend/notification-service/custom_metric.py
@@ -1,28 +1,4 @@
-from opentelemetry import metrics
-from opentelemetry.sdk.metrics import MeterProvider
-from opentelemetry.exporter.otlp.proto.http.metric_exporter import OTLPMetricExporter
-from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
-import os
-
-# Set the CA certificate path via an environment variable
-os.environ["REQUESTS_CA_BUNDLE"] = "/app/acp_root_ca.crt"
-
-# Initialize OpenTelemetry Metric Exporter
-exporter = OTLPMetricExporter(
-    endpoint="https://dynatrace-activegate-notprod.dynatrace.svc.cluster.local/e/ewo35763/api/v2/otlp/v1/metrics",
-    headers={
-        "Authorization": f"Api-Token {os.getenv('DYNATRACE_PAAS_TOKEN')}",
-        "Content-Type": "application/x-protobuf"
-    },
-)
-
-# Set up the MeterProvider with the exporter
-reader = PeriodicExportingMetricReader(exporter)
-provider = MeterProvider(metric_readers=[reader])
-metrics.set_meter_provider(provider)
-
-# Get a meter instance for this module
-meter = metrics.get_meter("notification-service", "0.1.2")
+from otel_config import meter
 
 # Create a counter for login events
 login_event_counter = meter.create_up_down_counter(

--- a/backend/notification-service/db.py
+++ b/backend/notification-service/db.py
@@ -1,7 +1,7 @@
 import psycopg2
 import os
 from otel_config import meter
-from opentelemetry.sdk.metrics import Observation
+from opentelemetry.sdk.metrics._internal.observation import Observation
 
 # Database connection details
 POSTGRES_HOST = os.getenv("POSTGRES_HOST")

--- a/backend/notification-service/db.py
+++ b/backend/notification-service/db.py
@@ -1,7 +1,7 @@
 import psycopg2
 import os
 from otel_config import meter
-from opentelemetry.sdk.metrics.callback import Observation
+from opentelemetry.metrics import Observation
 
 
 # Database connection details

--- a/backend/notification-service/db.py
+++ b/backend/notification-service/db.py
@@ -1,7 +1,7 @@
 import psycopg2
 import os
 from otel_config import meter
-from opentelemetry.metrics import Observation
+from opentelemetry.sdk.metrics import Observation
 
 
 # Database connection details
@@ -106,7 +106,7 @@ def get_login_total_count():
         return []
 
 
-def db_login_count_callback():
+def db_login_count_callback(options):
     count = get_login_total_count()
     return [Observation(value=count, attributes={})]
 

--- a/backend/notification-service/db.py
+++ b/backend/notification-service/db.py
@@ -1,6 +1,6 @@
 import psycopg2
 import os
-from otel_config import meter, tracer
+from otel_config import meter
 
 # Database connection details
 POSTGRES_HOST = os.getenv("POSTGRES_HOST")

--- a/backend/notification-service/db.py
+++ b/backend/notification-service/db.py
@@ -51,3 +51,21 @@ def test_db_connection():
     except Exception as e:
         print(f"Error connecting to the database: {e}")
         raise
+
+def increment_login_count():
+    """Increment the total_count in the login_counts table."""
+    try:
+        conn = get_db_connection()
+        cursor = conn.cursor()
+        cursor.execute("""
+            UPDATE login_counts
+            SET total_count = total_count + 1
+            WHERE id = 1;
+        """)
+        conn.commit()
+        cursor.close()
+        conn.close()
+        print("Successfully incremented total_count in the database.")
+    except Exception as e:
+        print(f"Error incrementing total_count in the database: {e}")
+        raise

--- a/backend/notification-service/db.py
+++ b/backend/notification-service/db.py
@@ -1,0 +1,53 @@
+import psycopg2
+import os
+
+# Database connection details
+POSTGRES_HOST = os.getenv("POSTGRES_HOST")
+POSTGRES_PORT = os.getenv("POSTGRES_PORT")
+POSTGRES_DB = os.getenv("POSTGRES_DB")
+POSTGRES_USER = os.getenv("POSTGRES_USER")
+POSTGRES_PASSWORD = os.getenv("POSTGRES_PASSWORD")
+
+# Connect to PostgreSQL
+def get_db_connection():
+    conn = psycopg2.connect(
+        host=POSTGRES_HOST,
+        port=POSTGRES_PORT,
+        database=POSTGRES_DB,
+        user=POSTGRES_USER,
+        password=POSTGRES_PASSWORD
+    )
+    return conn
+
+# Initialize the database table
+def initialize_db():
+    conn = get_db_connection()
+    cursor = conn.cursor()
+    cursor.execute("""
+        CREATE TABLE IF NOT EXISTS login_counts (
+            id SERIAL PRIMARY KEY,
+            total_count INT NOT NULL
+        );
+    """)
+    cursor.execute("""
+        INSERT INTO login_counts (total_count)
+        SELECT 0 WHERE NOT EXISTS (SELECT 1 FROM login_counts);
+    """)
+    conn.commit()
+    cursor.close()
+    conn.close()
+
+from db import get_db_connection
+
+try:
+    conn = get_db_connection()
+    cursor = conn.cursor()
+    cursor.execute("SELECT * FROM login_counts;")
+    rows = cursor.fetchall()
+    print("Database is working. Rows in login_counts table:")
+    for row in rows:
+        print(row)
+    cursor.close()
+    conn.close()
+except Exception as e:
+    print(f"Error connecting to the database: {e}")

--- a/backend/notification-service/db.py
+++ b/backend/notification-service/db.py
@@ -1,7 +1,7 @@
 import psycopg2
 import os
 from otel_config import meter
-from opentelemetry.sdk.metrics import Observation
+from opentelemetry.sdk.metrics.callback import Observation
 
 
 # Database connection details

--- a/backend/notification-service/db.py
+++ b/backend/notification-service/db.py
@@ -1,7 +1,6 @@
 import psycopg2
 import os
 from otel_config import meter
-from opentelemetry.sdk.metrics import Observation
 
 
 # Database connection details
@@ -85,7 +84,8 @@ def increment_login_count():
         print(f"Error incrementing total_count in the database: {e}")
         raise
 
-def get_login_total_count():
+
+def get_login_total_count(options):
     try:
         conn = get_db_connection()
         cursor = conn.cursor()
@@ -105,17 +105,16 @@ def get_login_total_count():
         print(f"Error observing login count: {e}")
         return []
 
-
-def db_login_count_callback(options):
-    count = get_login_total_count()
-    return [Observation(value=count, attributes={})]
-
-login_counter = meter.create_observable_gauge(
+# Create a counter for total login counts
+meter.create_observable_gauge(
     name="db_total_login_counts",
     description="Number of total logins recorded in the database",
     unit="1",
-    callbacks=[db_login_count_callback]
+    callbacks=[get_login_total_count]
 )
+
+
+
 
 
 

--- a/backend/notification-service/db.py
+++ b/backend/notification-service/db.py
@@ -1,5 +1,6 @@
 import psycopg2
 import os
+from otel_config import meter, tracer
 
 # Database connection details
 POSTGRES_HOST = os.getenv("POSTGRES_HOST")
@@ -52,20 +53,39 @@ def test_db_connection():
         print(f"Error connecting to the database: {e}")
         raise
 
+# Create a counter for login events
+db_login_event_counter = meter.create_up_down_counter(
+    name="db_login_event_counter",
+    description="Counts the number of login events processed in the deployed database",
+    unit="1"
+)
+
+# Increment login count with tracing
 def increment_login_count():
-    """Increment the total_count in the login_counts table."""
-    try:
-        conn = get_db_connection()
-        cursor = conn.cursor()
-        cursor.execute("""
-            UPDATE login_counts
-            SET total_count = total_count + 1
-            WHERE id = 1;
-        """)
-        conn.commit()
-        cursor.close()
-        conn.close()
-        print("Successfully incremented total_count in the database.")
-    except Exception as e:
-        print(f"Error incrementing total_count in the database: {e}")
-        raise
+    """Increment the total_count in the login_counts table with tracing."""
+    with tracer.start_as_current_span("increment_login_count") as span:
+        try:
+            conn = get_db_connection()
+            cursor = conn.cursor()
+            cursor.execute("""
+                UPDATE login_counts
+                SET total_count = total_count + 1
+                WHERE id = 1;
+            """)
+            conn.commit()
+            cursor.close()
+            conn.close()
+
+            # Add tracing attributes
+            span.set_attribute("db.operation", "UPDATE")
+            span.set_attribute("db.table", "login_counts")
+            span.set_attribute("db.status", "success")
+            print("Successfully incremented total_count in the database.")
+
+            # Increment the OpenTelemetry UpDownCounter
+            db_login_event_counter.add(1, {"db.table": "login_counts", "operation": "increment"})
+        except Exception as e:
+            span.set_attribute("db.status", "failure")
+            span.set_attribute("db.error", str(e))
+            print(f"Error incrementing total_count in the database: {e}")
+            raise

--- a/backend/notification-service/db.py
+++ b/backend/notification-service/db.py
@@ -60,24 +60,23 @@ db_login_event_counter = meter.create_up_down_counter(
     unit="1"
 )
 
-# Increment login count with metrics
-def increment_login_count():
-    """Increment the total_count in the login_counts table and update metrics."""
+# Fetch the total_count from the database and update the counter
+def update_db_login_event_counter():
+    """Fetch the total_count from the database and update the counter."""
     try:
         conn = get_db_connection()
         cursor = conn.cursor()
-        cursor.execute("""
-            UPDATE login_counts
-            SET total_count = total_count + 1
-            WHERE id = 1;
-        """)
-        conn.commit()
+        cursor.execute("SELECT total_count FROM login_counts WHERE id = 1;")
+        result = cursor.fetchone()
         cursor.close()
         conn.close()
 
-        # Increment the OpenTelemetry UpDownCounter
-        db_login_event_counter.add(1, {"db.table": "login_counts", "operation": "increment"})
-        print("Successfully incremented total_count in the database.")
+        if result:
+            total_count = result[0]
+            # Update the OpenTelemetry counter
+            db_login_event_counter.add(total_count, {"db.table": "login_counts", "operation": "fetch"})
+            print(f"Updated db_login_event_counter to {total_count}.")
+        else:
+            print("No total_count found in the database.")
     except Exception as e:
-        print(f"Error incrementing total_count in the database: {e}")
-        raise
+        print(f"Error updating db_login_event_counter: {e}")

--- a/backend/notification-service/db.py
+++ b/backend/notification-service/db.py
@@ -1,6 +1,7 @@
 import psycopg2
 import os
 from otel_config import meter
+from opentelemetry.metrics import Observation
 
 
 # Database connection details
@@ -97,13 +98,13 @@ def get_login_total_count(options):
         if result:
             total_count = result[0]
             print(f"[METRIC] Reporting total_count = {total_count}")
-            return [Observation(value=total_count, attributes={"db.table": "login_counts"})]
+            yield Observation(value=total_count, attributes={"db.table": "login_counts"})
         else:
             print("No total_count found in the database.")
-            return []
     except Exception as e:
         print(f"Error observing login count: {e}")
-        return []
+
+
 
 # Create a counter for total login counts
 meter.create_observable_gauge(

--- a/backend/notification-service/db.py
+++ b/backend/notification-service/db.py
@@ -37,17 +37,17 @@ def initialize_db():
     cursor.close()
     conn.close()
 
-from db import get_db_connection
-
-try:
-    conn = get_db_connection()
-    cursor = conn.cursor()
-    cursor.execute("SELECT * FROM login_counts;")
-    rows = cursor.fetchall()
-    print("Database is working. Rows in login_counts table:")
-    for row in rows:
-        print(row)
-    cursor.close()
-    conn.close()
-except Exception as e:
-    print(f"Error connecting to the database: {e}")
+def test_db_connection():
+    try:
+        conn = get_db_connection()
+        cursor = conn.cursor()
+        cursor.execute("SELECT * FROM login_counts;")
+        rows = cursor.fetchall()
+        print("Database connection successful. Rows in login_counts table:")
+        for row in rows:
+            print(row)
+        cursor.close()
+        conn.close()
+    except Exception as e:
+        print(f"Error connecting to the database: {e}")
+        raise

--- a/backend/notification-service/kafka_consumer.py
+++ b/backend/notification-service/kafka_consumer.py
@@ -4,6 +4,7 @@ import asyncio
 from datetime import datetime
 from kafka import KafkaConsumer
 from ssl import create_default_context
+from db import increment_login_count
 from custom_metric import login_event_counter
 import os
 
@@ -40,6 +41,8 @@ async def start_consumer(bootstrap_servers, topic, group_id, recent_logins, max_
       )
       
       logger.info("Kafka consumer initialised, waiting for messages...")
+      # Increment the total_count in the database
+      increment_login_count()
       
       # Process messages
       for message in consumer:
@@ -80,6 +83,9 @@ async def start_consumer(bootstrap_servers, topic, group_id, recent_logins, max_
                     # Increment the counter metric
                     login_event_counter.add(1, {"event_type": "login"})
                     logging.info("Custom metric 'login_event_counter' incremented by 1.")
+
+                    # Increment the total_count in the database
+                    increment_login_count()
                 else:
                     logging.warning("Unexpected message format. Skipping.")
 

--- a/backend/notification-service/kafka_consumer.py
+++ b/backend/notification-service/kafka_consumer.py
@@ -81,9 +81,6 @@ async def start_consumer(bootstrap_servers, topic, group_id, recent_logins, max_
                     # Increment the counter metric
                     login_event_counter.add(1, {"event_type": "login"})
                     logging.info("Custom metric 'login_event_counter' incremented by 1.")
-
-                    # Increment the total_count in the database
-                    increment_login_count()
                 else:
                     logging.warning("Unexpected message format. Skipping.")
 

--- a/backend/notification-service/kafka_consumer.py
+++ b/backend/notification-service/kafka_consumer.py
@@ -5,7 +5,6 @@ from datetime import datetime
 from kafka import KafkaConsumer
 from ssl import create_default_context
 from custom_metric import login_event_counter
-from db import increment_login_count
 import os
 
 logger = logging.getLogger(__name__)

--- a/backend/notification-service/kafka_consumer.py
+++ b/backend/notification-service/kafka_consumer.py
@@ -5,6 +5,7 @@ from datetime import datetime
 from kafka import KafkaConsumer
 from ssl import create_default_context
 from custom_metric import login_event_counter
+from db import increment_login_count
 import os
 
 logger = logging.getLogger(__name__)
@@ -79,8 +80,10 @@ async def start_consumer(bootstrap_servers, topic, group_id, recent_logins, max_
 
                     # Increment the counter metric
                     login_event_counter.add(1, {"event_type": "login"})
-
                     logging.info("Custom metric 'login_event_counter' incremented by 1.")
+
+                    # Increment the total_count in the database
+                    increment_login_count()
                 else:
                     logging.warning("Unexpected message format. Skipping.")
 

--- a/backend/notification-service/kafka_consumer.py
+++ b/backend/notification-service/kafka_consumer.py
@@ -6,8 +6,12 @@ from kafka import KafkaConsumer
 from ssl import create_default_context
 from custom_metric import login_event_counter
 import os
+from db import initialize_db
 
 logger = logging.getLogger(__name__)
+
+# Initialize the database
+initialize_db()
 
 async def start_consumer(bootstrap_servers, topic, group_id, recent_logins, max_logins, sdk=None):
   """Start consuming login events from kafka"""

--- a/backend/notification-service/kafka_consumer.py
+++ b/backend/notification-service/kafka_consumer.py
@@ -6,24 +6,8 @@ from kafka import KafkaConsumer
 from ssl import create_default_context
 from custom_metric import login_event_counter
 import os
-from db import initialize_db, test_db_connection
 
 logger = logging.getLogger(__name__)
-
-# Initialize the database
-try:
-    initialize_db()
-    logging.info("Database initialized successfully.")
-except Exception as e:
-    logging.error(f"Error initializing the database: {e}")
-    raise
-
-# Test the database connection
-try:
-    test_db_connection()
-except Exception as e:
-    logging.error(f"Database connection test failed: {e}")
-    raise
 
 async def start_consumer(bootstrap_servers, topic, group_id, recent_logins, max_logins, sdk=None):
   """Start consuming login events from kafka"""
@@ -51,7 +35,8 @@ async def start_consumer(bootstrap_servers, topic, group_id, recent_logins, max_
         group_id=group_id,
         security_protocol='SSL',
         ssl_context=ssl_context,
-        session_timeout_ms=30000,
+        session_timeout_ms=60000,
+        heartbeat_interval_ms=20000
       )
       
       logger.info("Kafka consumer initialised, waiting for messages...")

--- a/backend/notification-service/kafka_consumer.py
+++ b/backend/notification-service/kafka_consumer.py
@@ -6,12 +6,24 @@ from kafka import KafkaConsumer
 from ssl import create_default_context
 from custom_metric import login_event_counter
 import os
-from db import initialize_db
+from db import initialize_db, test_db_connection
 
 logger = logging.getLogger(__name__)
 
 # Initialize the database
-initialize_db()
+try:
+    initialize_db()
+    logging.info("Database initialized successfully.")
+except Exception as e:
+    logging.error(f"Error initializing the database: {e}")
+    raise
+
+# Test the database connection
+try:
+    test_db_connection()
+except Exception as e:
+    logging.error(f"Database connection test failed: {e}")
+    raise
 
 async def start_consumer(bootstrap_servers, topic, group_id, recent_logins, max_logins, sdk=None):
   """Start consuming login events from kafka"""

--- a/backend/notification-service/main.py
+++ b/backend/notification-service/main.py
@@ -103,8 +103,6 @@ async def startup_event():
       recent_logins=recent_logins, 
       max_logins=MAX_STORED_LOGINS, 
       sdk=sdk,
-      session_timeout_ms=60000,
-      heartbeat_interval_ms=20000
       )
   )
 

--- a/backend/notification-service/main.py
+++ b/backend/notification-service/main.py
@@ -16,20 +16,20 @@ logging.basicConfig(
 )
 logger = logging.getLogger(__name__)
 
-# Initialize the database
-try:
-    initialize_db()
-    logging.info("Database initialized successfully.")
-except Exception as e:
-    logging.error(f"Error initializing the database: {e}")
-    raise
+# # Initialize the database
+# try:
+#     initialize_db()
+#     logging.info("Database initialized successfully.")
+# except Exception as e:
+#     logging.error(f"Error initializing the database: {e}")
+#     raise
 
-# Test the database connection
-try:
-    test_db_connection()
-except Exception as e:
-    logging.error(f"Database connection test failed: {e}")
-    raise
+# # Test the database connection
+# try:
+#     test_db_connection()
+# except Exception as e:
+#     logging.error(f"Database connection test failed: {e}")
+#     raise
 
 oneagent_init = oneagent.initialize()
 if not oneagent_init:

--- a/backend/notification-service/main.py
+++ b/backend/notification-service/main.py
@@ -16,20 +16,20 @@ logging.basicConfig(
 )
 logger = logging.getLogger(__name__)
 
-# # Initialize the database
-# try:
-#     initialize_db()
-#     logging.info("Database initialized successfully.")
-# except Exception as e:
-#     logging.error(f"Error initializing the database: {e}")
-#     raise
+# Initialize the database
+try:
+    initialize_db()
+    logging.info("Database initialized successfully.")
+except Exception as e:
+    logging.error(f"Error initializing the database: {e}")
+    raise
 
-# # Test the database connection
-# try:
-#     test_db_connection()
-# except Exception as e:
-#     logging.error(f"Database connection test failed: {e}")
-#     raise
+# Test the database connection
+try:
+    test_db_connection()
+except Exception as e:
+    logging.error(f"Database connection test failed: {e}")
+    raise
 
 oneagent_init = oneagent.initialize()
 if not oneagent_init:

--- a/backend/notification-service/main.py
+++ b/backend/notification-service/main.py
@@ -34,12 +34,6 @@ except Exception as e:
     logging.error(f"Database connection test failed: {e}")
     raise
 
-async def update_db_counter_periodically():
-    """Periodically update the db_login_event_counter."""
-    while True:
-        update_db_login_event_counter()
-        await asyncio.sleep(30)  # Update every 30 seconds
-
 oneagent_init = oneagent.initialize()
 if not oneagent_init:
   logging.warning('Error initializing OneAgent SDK.')
@@ -111,8 +105,6 @@ async def startup_event():
       sdk=sdk,
       )
   )
-  # Start the periodic task to update the db_login_event_counter
-  asyncio.create_task(update_db_counter_periodically())
 
 if __name__ == "__main__":
   import uvicorn

--- a/backend/notification-service/main.py
+++ b/backend/notification-service/main.py
@@ -6,8 +6,6 @@ import asyncio
 from kafka_consumer import start_consumer
 import oneagent
 import oneagent.sdk
-from db import initialize_db, test_db_connection
-
 
 # Configure logging
 logging.basicConfig(
@@ -15,24 +13,6 @@ logging.basicConfig(
   format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
 )
 logger = logging.getLogger(__name__)
-
-# # Initialize the database
-# try:
-#     logging.info("Starting database initialization...")
-#     initialize_db()
-#     logging.info("Database initialized successfully.")
-# except Exception as e:
-#     logging.error(f"Error initializing the database: {e}")
-#     raise
-
-# # Test the database connection
-# try:
-#     logging.info("Starting database connection test...")
-#     test_db_connection()
-#     logging.info("Database connection test successful.")
-# except Exception as e:
-#     logging.error(f"Database connection test failed: {e}")
-#     raise
 
 oneagent_init = oneagent.initialize()
 if not oneagent_init:

--- a/backend/notification-service/main.py
+++ b/backend/notification-service/main.py
@@ -96,7 +96,16 @@ def simulate_login(email: str = "user@example.com"):
 async def startup_event():
   """Start kafka consumer on startup"""
   asyncio.create_task(
-    start_consumer(bootstrap_servers=KAFKA_SERVERS, topic=KAFKA_TOPIC, group_id=KAFKA_GROUP_ID, recent_logins=recent_logins, max_logins=MAX_STORED_LOGINS, sdk=sdk)
+    start_consumer(
+      bootstrap_servers=KAFKA_SERVERS, 
+      topic=KAFKA_TOPIC, 
+      group_id=KAFKA_GROUP_ID, 
+      recent_logins=recent_logins, 
+      max_logins=MAX_STORED_LOGINS, 
+      sdk=sdk,
+      session_timeout_ms=60000,
+      heartbeat_interval_ms=20000
+      )
   )
 
 if __name__ == "__main__":

--- a/backend/notification-service/main.py
+++ b/backend/notification-service/main.py
@@ -6,7 +6,7 @@ import asyncio
 from kafka_consumer import start_consumer
 import oneagent
 import oneagent.sdk
-from db import initialize_db, test_db_connection
+from db import initialize_db, test_db_connection, update_db_login_event_counter
 
 
 # Configure logging
@@ -33,6 +33,12 @@ try:
 except Exception as e:
     logging.error(f"Database connection test failed: {e}")
     raise
+
+async def update_db_counter_periodically():
+    """Periodically update the db_login_event_counter."""
+    while True:
+        update_db_login_event_counter()
+        await asyncio.sleep(30)  # Update every 30 seconds
 
 oneagent_init = oneagent.initialize()
 if not oneagent_init:
@@ -105,6 +111,8 @@ async def startup_event():
       sdk=sdk,
       )
   )
+  # Start the periodic task to update the db_login_event_counter
+  asyncio.create_task(update_db_counter_periodically())
 
 if __name__ == "__main__":
   import uvicorn

--- a/backend/notification-service/main.py
+++ b/backend/notification-service/main.py
@@ -16,23 +16,23 @@ logging.basicConfig(
 )
 logger = logging.getLogger(__name__)
 
-# Initialize the database
-try:
-    logging.info("Starting database initialization...")
-    initialize_db()
-    logging.info("Database initialized successfully.")
-except Exception as e:
-    logging.error(f"Error initializing the database: {e}")
-    raise
+# # Initialize the database
+# try:
+#     logging.info("Starting database initialization...")
+#     initialize_db()
+#     logging.info("Database initialized successfully.")
+# except Exception as e:
+#     logging.error(f"Error initializing the database: {e}")
+#     raise
 
-# Test the database connection
-try:
-    logging.info("Starting database connection test...")
-    test_db_connection()
-    logging.info("Database connection test successful.")
-except Exception as e:
-    logging.error(f"Database connection test failed: {e}")
-    raise
+# # Test the database connection
+# try:
+#     logging.info("Starting database connection test...")
+#     test_db_connection()
+#     logging.info("Database connection test successful.")
+# except Exception as e:
+#     logging.error(f"Database connection test failed: {e}")
+#     raise
 
 oneagent_init = oneagent.initialize()
 if not oneagent_init:

--- a/backend/notification-service/main.py
+++ b/backend/notification-service/main.py
@@ -6,6 +6,8 @@ import asyncio
 from kafka_consumer import start_consumer
 import oneagent
 import oneagent.sdk
+from db import initialize_db, test_db_connection
+
 
 # Configure logging
 logging.basicConfig(
@@ -13,6 +15,24 @@ logging.basicConfig(
   format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
 )
 logger = logging.getLogger(__name__)
+
+# Initialize the database
+try:
+    logging.info("Starting database initialization...")
+    initialize_db()
+    logging.info("Database initialized successfully.")
+except Exception as e:
+    logging.error(f"Error initializing the database: {e}")
+    raise
+
+# Test the database connection
+try:
+    logging.info("Starting database connection test...")
+    test_db_connection()
+    logging.info("Database connection test successful.")
+except Exception as e:
+    logging.error(f"Database connection test failed: {e}")
+    raise
 
 oneagent_init = oneagent.initialize()
 if not oneagent_init:

--- a/backend/notification-service/main.py
+++ b/backend/notification-service/main.py
@@ -6,6 +6,8 @@ import asyncio
 from kafka_consumer import start_consumer
 import oneagent
 import oneagent.sdk
+from db import initialize_db, test_db_connection
+
 
 # Configure logging
 logging.basicConfig(
@@ -13,6 +15,21 @@ logging.basicConfig(
   format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
 )
 logger = logging.getLogger(__name__)
+
+# Initialize the database
+try:
+    initialize_db()
+    logging.info("Database initialized successfully.")
+except Exception as e:
+    logging.error(f"Error initializing the database: {e}")
+    raise
+
+# Test the database connection
+try:
+    test_db_connection()
+except Exception as e:
+    logging.error(f"Database connection test failed: {e}")
+    raise
 
 oneagent_init = oneagent.initialize()
 if not oneagent_init:

--- a/backend/notification-service/main.py
+++ b/backend/notification-service/main.py
@@ -6,7 +6,7 @@ import asyncio
 from kafka_consumer import start_consumer
 import oneagent
 import oneagent.sdk
-from db import initialize_db, test_db_connection, update_db_login_event_counter
+from db import initialize_db, test_db_connection
 
 
 # Configure logging

--- a/backend/notification-service/main.py
+++ b/backend/notification-service/main.py
@@ -18,6 +18,7 @@ logger = logging.getLogger(__name__)
 
 # Initialize the database
 try:
+    logging.info("Starting database initialization...")
     initialize_db()
     logging.info("Database initialized successfully.")
 except Exception as e:
@@ -26,7 +27,9 @@ except Exception as e:
 
 # Test the database connection
 try:
+    logging.info("Starting database connection test...")
     test_db_connection()
+    logging.info("Database connection test successful.")
 except Exception as e:
     logging.error(f"Database connection test failed: {e}")
     raise

--- a/backend/notification-service/notification-service-chart/templates/deployment.yaml
+++ b/backend/notification-service/notification-service-chart/templates/deployment.yaml
@@ -83,6 +83,25 @@ spec:
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           env:
+            - name: POSTGRES_HOST
+              value: "postgresql.default.svc.cluster.local"
+            - name: POSTGRES_PORT
+              value: "5432"
+            - name: POSTGRES_DB
+              valueFrom:
+                secretKeyRef:
+                  name: postgresql-secret
+                  key: POSTGRES_DB
+            - name: POSTGRES_USER
+              valueFrom:
+                secretKeyRef:
+                  name: postgresql-secret
+                  key: POSTGRES_USER
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: postgresql-secret
+                  key: POSTGRES_PASSWORD
             - name: DYNATRACE_PAAS_TOKEN
               valueFrom:
                 secretKeyRef:

--- a/backend/notification-service/notification-service-chart/templates/deployment.yaml
+++ b/backend/notification-service/notification-service-chart/templates/deployment.yaml
@@ -88,12 +88,9 @@ spec:
             - name: POSTGRES_PORT
               value: "5432"
             - name: POSTGRES_DB
-              valueFrom:
-                secretKeyRef:
-                  name: postgresql-secret
-                  key: POSTGRES_DB
+              value: "db_logins"
             - name: POSTGRES_USER
-              value: postgres
+              value: "postgres"
             - name: POSTGRES_PASSWORD
               valueFrom:
                 secretKeyRef:

--- a/backend/notification-service/notification-service-chart/templates/deployment.yaml
+++ b/backend/notification-service/notification-service-chart/templates/deployment.yaml
@@ -84,7 +84,7 @@ spec:
             {{- toYaml .Values.resources | nindent 12 }}
           env:
             - name: POSTGRES_HOST
-              value: "postgresql.default.svc.cluster.local"
+              value: "notification-service-db.dsa-re-dev.svc.cluster.local"
             - name: POSTGRES_PORT
               value: "5432"
             - name: POSTGRES_DB
@@ -93,10 +93,7 @@ spec:
                   name: postgresql-secret
                   key: POSTGRES_DB
             - name: POSTGRES_USER
-              valueFrom:
-                secretKeyRef:
-                  name: postgresql-secret
-                  key: POSTGRES_USER
+              value: postgres
             - name: POSTGRES_PASSWORD
               valueFrom:
                 secretKeyRef:

--- a/backend/notification-service/notification-service-templates-db/deployment.yaml
+++ b/backend/notification-service/notification-service-templates-db/deployment.yaml
@@ -25,10 +25,7 @@ spec:
         - containerPort: 5432
         env:
         - name: POSTGRES_USER
-          valueFrom:
-            secretKeyRef:
-              name: postgresql-secret
-              key: POSTGRES_USER
+          value: "postgres"
         - name: POSTGRES_PASSWORD
           valueFrom:
             secretKeyRef:

--- a/backend/notification-service/notification-service-templates-db/deployment.yaml
+++ b/backend/notification-service/notification-service-templates-db/deployment.yaml
@@ -7,17 +7,20 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      app: notification-service-db
+      app.kubernetes.io/instance: notification-service-db
+      app.kubernetes.io/name: notification-service-db
+  ingress:
   template:
     metadata:
       labels:
-        app: notification-service-db
+        app.kubernetes.io/instance: notification-service-db
+        app.kubernetes.io/name: notification-service-db
     spec:
       securityContext:
         fsGroup: 999
       containers:
       - name: postgres
-        image: quay.io/ukhomeofficedigital/dsa-re-notification-service-db
+        image: quay.io/ukhomeofficedigital/dsa-re-notification-service-db:latest
         ports:
         - containerPort: 5432
         env:

--- a/backend/notification-service/notification-service-templates-db/deployment.yaml
+++ b/backend/notification-service/notification-service-templates-db/deployment.yaml
@@ -1,0 +1,43 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: notification-service-db
+  namespace: dsa-re-dev
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: notification-service-db
+  template:
+    metadata:
+      labels:
+        app: notification-service-db
+    spec:
+      securityContext:
+        fsGroup: 999
+      containers:
+      - name: postgres
+        image: quay.io/ukhomeofficedigital/dsa-re-notification-service-db
+        ports:
+        - containerPort: 5432
+        env:
+        - name: POSTGRES_USER
+          valueFrom:
+            secretKeyRef:
+              name: postgresql-secret
+              key: POSTGRES_USER
+        - name: POSTGRES_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: postgresql-secret
+              key: POSTGRES_PASSWORD
+        volumeMounts:
+        - mountPath: /var/lib/postgresql/data
+          name: postgres-storage
+        securityContext:
+          runAsUser: 999
+          runAsGroup: 999
+      volumes:
+      - name: postgres-storage
+        persistentVolumeClaim:
+          claimName: postgres-pvc

--- a/backend/notification-service/notification-service-templates-db/deployment.yaml
+++ b/backend/notification-service/notification-service-templates-db/deployment.yaml
@@ -31,13 +31,15 @@ spec:
             secretKeyRef:
               name: postgresql-secret
               key: POSTGRES_PASSWORD
+        - name: PGDATA
+          value: /var/lib/postgresql/data/db
         volumeMounts:
         - mountPath: /var/lib/postgresql/data
-          name: postgres-storage
+          name: pgdata
         securityContext:
           runAsUser: 999
           runAsGroup: 999
       volumes:
-      - name: postgres-storage
+      - name: pgdata
         persistentVolumeClaim:
           claimName: postgres-pvc

--- a/backend/notification-service/notification-service-templates-db/networkpolicy.yaml
+++ b/backend/notification-service/notification-service-templates-db/networkpolicy.yaml
@@ -1,0 +1,24 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-db-access
+  namespace: dsa-re-dev
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/instance: notification-service-db
+      app.kubernetes.io/name: notification-service-db
+  ingress:
+    - from:
+      - podSelector:
+          matchLabels:
+            app.kubernetes.io/instance: notification-service
+            app.kubernetes.io/name: notification-service
+      ports:
+      - protocol: TCP
+        port: 5432
+  egress:
+    - {}
+  policyTypes:
+  - Ingress
+  - Egress

--- a/backend/notification-service/notification-service-templates-db/pvc.yaml
+++ b/backend/notification-service/notification-service-templates-db/pvc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: postgres-pvc
+  namespace: dsa-re-dev
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+  storageClassName: gp2-encrypted

--- a/backend/notification-service/notification-service-templates-db/service.yaml
+++ b/backend/notification-service/notification-service-templates-db/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: notification-service-db
+  namespace: dsa-re-dev
+spec:
+  selector:
+    app.kubernetes.io/instance: notification-service-db
+    app.kubernetes.io/name: notification-service-db
+  ports:
+  - protocol: TCP
+    port: 5432            
+    targetPort: 5432

--- a/backend/notification-service/otel_config.py
+++ b/backend/notification-service/otel_config.py
@@ -21,7 +21,7 @@ metric_exporter = OTLPMetricExporter(
 
 # Initialize OpenTelemetry Trace Exporter
 trace_exporter = OTLPSpanExporter(
-    endpoint="https://dynatrace-activegate-notprod.dynatrace.svc.cluster.local/e/ewo35763/api/v2/otlp/v1/metrics",
+    endpoint="https://dynatrace-activegate-notprod.dynatrace.svc.cluster.local/e/ewo35763/api/v2/otlp/v1/traces",
     headers={
         "Authorization": f"Api-Token {os.getenv('DYNATRACE_PAAS_TOKEN')}",
         "Content-Type": "application/x-protobuf"

--- a/backend/notification-service/otel_config.py
+++ b/backend/notification-service/otel_config.py
@@ -11,7 +11,16 @@ from opentelemetry.sdk.trace.export import BatchSpanProcessor
 os.environ["REQUESTS_CA_BUNDLE"] = "/app/acp_root_ca.crt"
 
 # Initialize OpenTelemetry Metric Exporter
-exporter = OTLPMetricExporter(
+metric_exporter = OTLPMetricExporter(
+    endpoint="https://dynatrace-activegate-notprod.dynatrace.svc.cluster.local/e/ewo35763/api/v2/otlp/v1/metrics",
+    headers={
+        "Authorization": f"Api-Token {os.getenv('DYNATRACE_PAAS_TOKEN')}",
+        "Content-Type": "application/x-protobuf"
+    },
+)
+
+# Initialize OpenTelemetry Trace Exporter
+trace_exporter = OTLPSpanExporter(
     endpoint="https://dynatrace-activegate-notprod.dynatrace.svc.cluster.local/e/ewo35763/api/v2/otlp/v1/metrics",
     headers={
         "Authorization": f"Api-Token {os.getenv('DYNATRACE_PAAS_TOKEN')}",
@@ -20,13 +29,13 @@ exporter = OTLPMetricExporter(
 )
 
 # Set up the MeterProvider with the Metric Exporter
-metric_reader = PeriodicExportingMetricReader(exporter)
+metric_reader = PeriodicExportingMetricReader(metric_exporter)
 meter_provider = MeterProvider(metric_readers=[metric_reader])
 metrics.set_meter_provider(meter_provider)
 
 # Set up the TracerProvider with the Trace Exporter
 tracer_provider = TracerProvider()
-span_processor = BatchSpanProcessor(exporter)
+span_processor = BatchSpanProcessor(trace_exporter)
 tracer_provider.add_span_processor(span_processor)
 trace.set_tracer_provider(tracer_provider)
 

--- a/backend/notification-service/otel_config.py
+++ b/backend/notification-service/otel_config.py
@@ -1,7 +1,6 @@
 import os
-from opentelemetry import trace, metrics
+from opentelemetry import metrics
 from opentelemetry.sdk.metrics import MeterProvider
-from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.exporter.otlp.proto.http.metric_exporter import OTLPMetricExporter
 from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
 from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
@@ -13,15 +12,6 @@ os.environ["REQUESTS_CA_BUNDLE"] = "/app/acp_root_ca.crt"
 # Initialize OpenTelemetry Metric Exporter
 metric_exporter = OTLPMetricExporter(
     endpoint="https://dynatrace-activegate-notprod.dynatrace.svc.cluster.local/e/ewo35763/api/v2/otlp/v1/metrics",
-    headers={
-        "Authorization": f"Api-Token {os.getenv('DYNATRACE_PAAS_TOKEN')}",
-        "Content-Type": "application/x-protobuf"
-    },
-)
-
-# Initialize OpenTelemetry Trace Exporter
-trace_exporter = OTLPSpanExporter(
-    endpoint="https://dynatrace-activegate-notprod.dynatrace.svc.cluster.local/e/ewo35763/api/v2/otlp/v1/traces",
     headers={
         "Authorization": f"Api-Token {os.getenv('DYNATRACE_PAAS_TOKEN')}",
         "Content-Type": "application/x-protobuf"

--- a/backend/notification-service/otel_config.py
+++ b/backend/notification-service/otel_config.py
@@ -1,0 +1,35 @@
+import os
+from opentelemetry import trace, metrics
+from opentelemetry.sdk.metrics import MeterProvider
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.exporter.otlp.proto.http.metric_exporter import OTLPMetricExporter
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+
+# Set the CA certificate path via an environment variable
+os.environ["REQUESTS_CA_BUNDLE"] = "/app/acp_root_ca.crt"
+
+# Initialize OpenTelemetry Metric Exporter
+exporter = OTLPMetricExporter(
+    endpoint="https://dynatrace-activegate-notprod.dynatrace.svc.cluster.local/e/ewo35763/api/v2/otlp/v1/metrics",
+    headers={
+        "Authorization": f"Api-Token {os.getenv('DYNATRACE_PAAS_TOKEN')}",
+        "Content-Type": "application/x-protobuf"
+    },
+)
+
+# Set up the MeterProvider with the Metric Exporter
+metric_reader = PeriodicExportingMetricReader(exporter)
+meter_provider = MeterProvider(metric_readers=[metric_reader])
+metrics.set_meter_provider(meter_provider)
+
+# Set up the TracerProvider with the Trace Exporter
+tracer_provider = TracerProvider()
+span_processor = BatchSpanProcessor(exporter)
+tracer_provider.add_span_processor(span_processor)
+trace.set_tracer_provider(tracer_provider)
+
+# Get reusable tracer and meter instances
+tracer = trace.get_tracer("notification-service")
+meter = metrics.get_meter("notification-service")

--- a/backend/notification-service/otel_config.py
+++ b/backend/notification-service/otel_config.py
@@ -33,12 +33,5 @@ metric_reader = PeriodicExportingMetricReader(metric_exporter)
 meter_provider = MeterProvider(metric_readers=[metric_reader])
 metrics.set_meter_provider(meter_provider)
 
-# Set up the TracerProvider with the Trace Exporter
-tracer_provider = TracerProvider()
-span_processor = BatchSpanProcessor(trace_exporter)
-tracer_provider.add_span_processor(span_processor)
-trace.set_tracer_provider(tracer_provider)
-
-# Get reusable tracer and meter instances
-tracer = trace.get_tracer("notification-service")
+# Get a reusable meter instance
 meter = metrics.get_meter("notification-service")

--- a/backend/notification-service/otel_config.py
+++ b/backend/notification-service/otel_config.py
@@ -4,7 +4,6 @@ from opentelemetry.sdk.metrics import MeterProvider
 from opentelemetry.exporter.otlp.proto.http.metric_exporter import OTLPMetricExporter
 from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
 from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
-from opentelemetry.sdk.trace.export import BatchSpanProcessor
 
 # Set the CA certificate path via an environment variable
 os.environ["REQUESTS_CA_BUNDLE"] = "/app/acp_root_ca.crt"

--- a/backend/notification-service/requirements.txt
+++ b/backend/notification-service/requirements.txt
@@ -3,8 +3,7 @@ uvicorn
 kafka-python
 python-dotenv
 oneagent-sdk
-opentelemetry-api==1.17.0
-opentelemetry-sdk==1.17.0
-opentelemetry-exporter-otlp==1.17.0
-opentelemetry-exporter-otlp-proto-http==1.17.0
+opentelemetry-api
+opentelemetry-sdk
+opentelemetry-exporter-otlp-proto-http
 psycopg2-binary

--- a/backend/notification-service/requirements.txt
+++ b/backend/notification-service/requirements.txt
@@ -6,4 +6,4 @@ oneagent-sdk
 opentelemetry-api
 opentelemetry-sdk
 opentelemetry-exporter-otlp-proto-http
-psycopg2
+psycopg2-binary

--- a/backend/notification-service/requirements.txt
+++ b/backend/notification-service/requirements.txt
@@ -5,5 +5,6 @@ python-dotenv
 oneagent-sdk
 opentelemetry-api==1.17.0
 opentelemetry-sdk==1.17.0
+opentelemetry-exporter-otlp==1.17.0
 opentelemetry-exporter-otlp-proto-http==1.17.0
 psycopg2-binary

--- a/backend/notification-service/requirements.txt
+++ b/backend/notification-service/requirements.txt
@@ -3,7 +3,7 @@ uvicorn
 kafka-python
 python-dotenv
 oneagent-sdk
-opentelemetry-api
-opentelemetry-sdk
-opentelemetry-exporter-otlp-proto-http
+opentelemetry-api==1.17.0
+opentelemetry-sdk==1.17.0
+opentelemetry-exporter-otlp-proto-http==1.17.0
 psycopg2-binary

--- a/backend/notification-service/requirements.txt
+++ b/backend/notification-service/requirements.txt
@@ -6,3 +6,4 @@ oneagent-sdk
 opentelemetry-api
 opentelemetry-sdk
 opentelemetry-exporter-otlp-proto-http
+psycopg2


### PR DESCRIPTION
**What**
- create the kubernetes manifests for the deployment of the postgres container to showcase metrics in a container db
- create a otel_config.py that set up python and otel for instrumentation
- create a db.py that connect to the database and two metrics that increases the total count of logins directly in the databases and another metric gauge that provide the total login count directly from the db
- add changes to the readme

**Technical decision**
- I have not created a helm chart to deploy the db as the objective was the showcase of the metrics integrations with a contianer db.
- I have not upgraded the deployment with a pipeline so the deployment is manual.

**Ticket**
RE-30