### PR TITLE
Documentation update on how to deploy with Helm

### DIFF
--- a/backend/registration-service/README.md
+++ b/backend/registration-service/README.md
@@ -49,7 +49,17 @@ This repository contains the Registration microservice for the Showcase Services
    mvn clean install
    ```
 
-## Running the Application
+## Running the Application Locally
+
+Note to run the application locally there is a prerequisite on having a PostgreSQL accessible to the app
+
+- Make sure to create a database and user in PostgreSQL with the necessary privileges.
+- Update the `application.properties` file with your database connection settings, such as:
+  ```properties
+  spring.datasource.url=jdbc:postgresql://localhost:5432/yourdbname
+  spring.datasource.username=yourusername
+  spring.datasource.password=yourpassword
+  ```
 
 1. **Start the application**:
 
@@ -59,6 +69,17 @@ This repository contains the Registration microservice for the Showcase Services
 
 2. **Access the API**:
    - The application will be running at `http://localhost:8080`.
+
+## Deploying via Helm
+
+At time of writing there is no pipeline-based Helm deployment. Deployments are done 'by hand' by executing the following command from within the charts directory:
+
+```
+helm -n dsa-re-dev upgrade registration-service . --values=values-dev.yaml
+```
+
+Remember that by deploying changes from locally branches you are potentially diverging what is deployed from the main branch.
+
 
 ## API Endpoints
 
@@ -87,23 +108,7 @@ This repository contains the Registration microservice for the Showcase Services
   }
   ```
 
-## Database Setup
 
-- Make sure to create a database and user in PostgreSQL with the necessary privileges.
-- Update the `application.properties` file with your database connection settings, such as:
-  ```properties
-  spring.datasource.url=jdbc:postgresql://localhost:5432/yourdbname
-  spring.datasource.username=yourusername
-  spring.datasource.password=yourpassword
-  ```
-### Containerised PostgreSQL
-
-For the purposes of getting up and running while a RDS instance was provisioned, a containerised version of PostgreSQL was deployed to the dsa-re-dev namespace using Helm and [an off-the-shelf Chart from bitnami](https://artifacthub.io/packages/helm/bitnami/postgresql). The values file for this can be found [here](./containerised-db-values-dev.yaml), and this was deployed as below:
-
-```bash
-$ helm repo add bitnami https://charts.bitnami.com/bitnami # Adds repo to the local Helm client
-$ helm install registration-service-postgresql bitnami/postgresql --version 16.0.4 --values=containerised-db-values-dev.yaml
-```
 
 ## Contributing
 

--- a/backend/registration-service/registration-service-chart/templates/deployment.yaml
+++ b/backend/registration-service/registration-service-chart/templates/deployment.yaml
@@ -36,7 +36,7 @@ spec:
       initContainers:
       {{- if((.Values.dynatrace).podRuntimeInjection).enabled }}
         - name: install-oneagent
-          image: quay.io/ukhomeofficedigital/dsa-re-dynatrace-oneagent-pod-runtime-injection:1.3.3
+          image: quay.io/ukhomeofficedigital/dsa-re-dynatrace-oneagent-pod-runtime-injection:1.0.0
           env:
             - name: DYNATRACE_API_URL
               valueFrom:

--- a/backend/registration-service/registration-service-chart/templates/deployment.yaml
+++ b/backend/registration-service/registration-service-chart/templates/deployment.yaml
@@ -9,6 +9,8 @@ spec:
   selector:
     matchLabels:
       {{- include "registration-service.selectorLabels" . | nindent 6 }}
+  strategy:
+    type: Recreate
   template:
     metadata:
       {{- with .Values.podAnnotations }}
@@ -34,7 +36,7 @@ spec:
       initContainers:
       {{- if((.Values.dynatrace).podRuntimeInjection).enabled }}
         - name: install-oneagent
-          image: quay.io/ukhomeofficedigital/dsa-re-dynatrace-oneagent-pod-runtime-injection:1.0.0
+          image: quay.io/ukhomeofficedigital/dsa-re-dynatrace-oneagent-pod-runtime-injection:1.3.3
           env:
             - name: DYNATRACE_API_URL
               valueFrom:


### PR DESCRIPTION
Updates the documentation to provide instructions on how to deploy with Helm.

Also:

- Removes section that is no longer valid around the Bitnami PostgreSQL image
- Changes the deployment type to Recreate. Ever since we moved to using a Kafka TLS volume, we see multi attach errors when trying to do a release, as the standard release is a RollingUpdate, and the volume can't be attached to more than one pod at any given time.