### PR TITLE
RE-494 Adds NetworkZone to all Showcase Services

### DIFF
--- a/backend/notification-service/notification-service-chart/templates/deployment.yaml
+++ b/backend/notification-service/notification-service-chart/templates/deployment.yaml
@@ -112,6 +112,8 @@ spec:
           {{- if((.Values.dynatrace).podRuntimeInjection).enabled }}
             - name: LD_PRELOAD
               value: /opt/dynatrace/oneagent/agent/lib64/liboneagentproc.so
+            - name: DT_NETWORK_ZONE
+              value: dsa-notprod-acp-notprod-rtg-00
           {{- end }}
           volumeMounts:
           {{- if((.Values.dynatrace).podRuntimeInjection).enabled }}

--- a/backend/registration-service/registration-service-chart/templates/deployment.yaml
+++ b/backend/registration-service/registration-service-chart/templates/deployment.yaml
@@ -36,7 +36,7 @@ spec:
       initContainers:
       {{- if((.Values.dynatrace).podRuntimeInjection).enabled }}
         - name: install-oneagent
-          image: quay.io/ukhomeofficedigital/dsa-re-dynatrace-oneagent-pod-runtime-injection:1.3.3
+          image: quay.io/ukhomeofficedigital/dsa-re-dynatrace-oneagent-pod-runtime-injection:latest
           env:
             - name: DYNATRACE_API_URL
               valueFrom:
@@ -54,6 +54,8 @@ spec:
               value: /opt/dynatrace/oneagent
             - name: DYNATRACE_NETWORK_ZONE
               value: dsa-notprod-acp-notprod-rtg-00
+            - name: DYNATRACE_ONEAGENT_VERSION
+              value: 1.319.76.20250819-104206
           volumeMounts:
             - mountPath: /opt/dynatrace/oneagent
               name: {{ (((.Values).dynatrace).podRuntimeInjection).volumeName | default "oneagent" }}

--- a/backend/registration-service/registration-service-chart/templates/deployment.yaml
+++ b/backend/registration-service/registration-service-chart/templates/deployment.yaml
@@ -36,7 +36,7 @@ spec:
       initContainers:
       {{- if((.Values.dynatrace).podRuntimeInjection).enabled }}
         - name: install-oneagent
-          image: quay.io/ukhomeofficedigital/dsa-re-dynatrace-oneagent-pod-runtime-injection:latest
+          image: quay.io/ukhomeofficedigital/dsa-re-dynatrace-oneagent-pod-runtime-injection:1.0.0
           env:
             - name: DYNATRACE_API_URL
               valueFrom:
@@ -52,10 +52,6 @@ spec:
               value: flavor=multidistro&include=java
             - name: DYNATRACE_INSTALL_DIR
               value: /opt/dynatrace/oneagent
-            - name: DYNATRACE_NETWORK_ZONE
-              value: dsa-notprod-acp-notprod-rtg-00
-            - name: DYNATRACE_ONEAGENT_VERSION
-              value: 1.319.76.20250819-104206
           volumeMounts:
             - mountPath: /opt/dynatrace/oneagent
               name: {{ (((.Values).dynatrace).podRuntimeInjection).volumeName | default "oneagent" }}
@@ -110,6 +106,8 @@ spec:
           env:
             - name: RANDOM
               value: {{ randAlphaNum 5 | quote }}
+            - name: DT_NETWORK_ZONE
+              value: dsa-notprod-acp-notprod-rtg-00
             - name: SHOWCASE_SERVICES_DB_ENDPOINT
               valueFrom:
                 secretKeyRef:

--- a/backend/registration-service/registration-service-chart/templates/deployment.yaml
+++ b/backend/registration-service/registration-service-chart/templates/deployment.yaml
@@ -36,7 +36,7 @@ spec:
       initContainers:
       {{- if((.Values.dynatrace).podRuntimeInjection).enabled }}
         - name: install-oneagent
-          image: quay.io/ukhomeofficedigital/dsa-re-dynatrace-oneagent-pod-runtime-injection:1.0.0
+          image: quay.io/ukhomeofficedigital/dsa-re-dynatrace-oneagent-pod-runtime-injection:1.3.3
           env:
             - name: DYNATRACE_API_URL
               valueFrom:
@@ -52,6 +52,8 @@ spec:
               value: flavor=multidistro&include=java
             - name: DYNATRACE_INSTALL_DIR
               value: /opt/dynatrace/oneagent
+            - name: DYNATRACE_NETWORK_ZONE
+              value: dsa-notprod-acp-notprod-rtg-00
           volumeMounts:
             - mountPath: /opt/dynatrace/oneagent
               name: {{ (((.Values).dynatrace).podRuntimeInjection).volumeName | default "oneagent" }}

--- a/frontend/frontend-service/frontend-service-chart/templates/deployment.yaml
+++ b/frontend/frontend-service/frontend-service-chart/templates/deployment.yaml
@@ -84,6 +84,8 @@ spec:
           {{- if((.Values.dynatrace).podRuntimeInjection).enabled }}
             - name: LD_PRELOAD
               value: /opt/dynatrace/oneagent/agent/lib64/liboneagentproc.so
+            - name: DT_NETWORK_ZONE
+              value: dsa-notprod-acp-notprod-rtg-00
           {{- end -}}
           {{- if((.Values.dynatrace).podRuntimeInjection).enabled }}
           volumeMounts:


### PR DESCRIPTION
Adds a NetworkZone to all Showcase Services. This is hardcoded at the moment into the templates and can be made into a Helm variable at the point where we have separate values files.

Notification service being a Python service does not currently show up as a monitored host at all, hence the discrepancy of 3 vs 2.