### PR TITLE
Ensures OneAgent works in Python processes

### DIFF
--- a/backend/notification-service/notification-service-chart/templates/deployment.yaml
+++ b/backend/notification-service/notification-service-chart/templates/deployment.yaml
@@ -34,7 +34,7 @@ spec:
       initContainers:
       {{- if((.Values.dynatrace).podRuntimeInjection).enabled }}
         - name: install-oneagent
-          image: quay.io/ukhomeofficedigital/dsa-re-dynatrace-oneagent-pod-runtime-injection:1.0.0
+          image: quay.io/ukhomeofficedigital/dsa-re-dynatrace-oneagent-pod-runtime-injection:1.3.4
           env:
             - name: DYNATRACE_API_URL
               valueFrom:
@@ -47,9 +47,11 @@ spec:
                   name: notification-service-dynatrace-oneagent
                   key: paas-installer-download-token
             - name: DYNATRACE_ONEAGENT_OPTIONS
-              value: flavor=multidistro&include=sdk
+              value: flavor=multidistro&include=python&include=sdk
             - name: DYNATRACE_INSTALL_DIR
               value: /opt/dynatrace/oneagent
+            - name: DYNATRACE_ONEAGENT_VERSION
+              value: "1.319.76.20250819-104206"
           volumeMounts:
             - mountPath: /opt/dynatrace/oneagent
               name: {{ (((.Values).dynatrace).podRuntimeInjection).volumeName | default "oneagent" }}


### PR DESCRIPTION
Working with Artur recently he has been struggling to get his Python service visible as a OneAgent instrumented service. I had a quick look into notification service and tried two changes based on reading around the documentation.

1. There is now a 'python' specific code module, I've added this as an include
2. I used a later version of the OneAgent. This was after reading https://community.dynatrace.com/t5/Dynatrace-tips/How-to-enable-Python-Applications-monitoring-with-OneAgent/m-p/281131 which implied there was a lot of manual stuff to do on the earlier version we were previously on.