### PR TITLE
RE-461 Upgrades Spring Boot as part of vulnerabilities work

### DIFF
--- a/backend/registration-service/pom.xml
+++ b/backend/registration-service/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.3.4</version>
+		<version>3.5.6</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.example</groupId>


### PR DESCRIPTION
Upgrades the Spring Boot version which pulls in several other libraries as part of it that are being flagged up by Trivvy scans