### PR TITLE
RE-461 Removes Kafka client library from Dockerfile

### DIFF
--- a/backend/registration-service/Dockerfile
+++ b/backend/registration-service/Dockerfile
@@ -30,12 +30,6 @@ FROM quay.io/ukhomeofficedigital/dsa-re-amazoncorretto:21.0.5-alpine3.20
 #Set working directory
 WORKDIR /app
 
-# Install Kafka client dependencies (Kafka tools)
-RUN apk add --no-cache bash wget && \
-    wget https://archive.apache.org/dist/kafka/3.0.0/kafka_2.13-3.0.0.tgz && \
-    tar -xzvf kafka_2.13-3.0.0.tgz && \
-    rm kafka_2.13-3.0.0.tgz
-
 # Copy over jar from stage 1
 COPY --from=builder app/target/registration-service-0.0.1-SNAPSHOT.jar app.jar
 


### PR DESCRIPTION
Have followed up with @chriswhunter89 but this doesn't seem to need to be in here, at least not on a permanent basis. From what I can see it maybe it time was used to write something out to the mounted PVC.

If I've got this correct and the above is right then we should be getting what is in the PVC and saving it as a Kubernetes Secret for this to mount.