### PR TITLE
Bumps base image to dsa-re-python:3.11.13-alpine3.22

### DIFF
--- a/backend/notification-service/Dockerfile
+++ b/backend/notification-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/ukhomeofficedigital/dsa-re-python:3.11.12-alpine3.21
+FROM quay.io/ukhomeofficedigital/dsa-re-python:3.11.13-alpine3.22
 
 WORKDIR /app
 


### PR DESCRIPTION
Bumps base image to a later Alpine version where the sqllite vulnerability should be patched that is being flagged in our vulnerability scans (CVE-2025-6965)