### PR TITLE
RE-461 Updates base image in use

### DIFF
--- a/frontend/frontend-service/Dockerfile
+++ b/frontend/frontend-service/Dockerfile
@@ -1,5 +1,5 @@
 # Build react app
-FROM quay.io/ukhomeofficedigital/dsa-re-node-18-alpine:18-alpine3.19 AS builder
+FROM quay.io/ukhomeofficedigital/dsa-re-node:18-alpine3.20 AS builder
 
 #Set working directory
 WORKDIR /app


### PR DESCRIPTION
Note the new image has a new namespace convention that better matches what is on docker.io, i.e. just having node in the image name and all the other info in the tag. 