### PR TITLE
Bump pod runtime image version to resolve missing OA version

### DIFF
--- a/backend/registration-service/registration-service-chart/templates/deployment.yaml
+++ b/backend/registration-service/registration-service-chart/templates/deployment.yaml
@@ -36,7 +36,7 @@ spec:
       initContainers:
       {{- if((.Values.dynatrace).podRuntimeInjection).enabled }}
         - name: install-oneagent
-          image: quay.io/ukhomeofficedigital/dsa-re-dynatrace-oneagent-pod-runtime-injection:1.0.0
+          image: quay.io/ukhomeofficedigital/dsa-re-dynatrace-oneagent-pod-runtime-injection:1.3.4
           env:
             - name: DYNATRACE_API_URL
               valueFrom:

--- a/frontend/frontend-service/frontend-service-chart/templates/deployment.yaml
+++ b/frontend/frontend-service/frontend-service-chart/templates/deployment.yaml
@@ -34,7 +34,7 @@ spec:
       {{- if((.Values.dynatrace).podRuntimeInjection).enabled }}
       initContainers:
         - name: install-oneagent
-          image: quay.io/ukhomeofficedigital/dsa-re-dynatrace-oneagent-pod-runtime-injection:1.0.0
+          image: quay.io/ukhomeofficedigital/dsa-re-dynatrace-oneagent-pod-runtime-injection:1.3.4
           env:
             - name: DYNATRACE_API_URL
               valueFrom:


### PR DESCRIPTION
- Bumps frontend-service pod runtime image version to 1.3.4
- Bumps registration-service pod runtime image version to 1.3.4